### PR TITLE
修正: AI変換ログCRUDの二重コミットを解消しトランザクション境界を一元化

### DIFF
--- a/backend/app/crud/crud_ai_conversion.py
+++ b/backend/app/crud/crud_ai_conversion.py
@@ -60,8 +60,11 @@ async def create_conversion_log(
     )
 
     # データベースに追加
+    # コミットはリクエスト境界（get_db）に一元化する。ここでコミットすると、
+    # 同一リクエスト内の後続DB操作との原子性が失われるため flush に留める。
+    # flush で主キー等が採番され、返却オブジェクトを呼び出し側で利用できる。
     db.add(log)
-    await db.commit()
+    await db.flush()
     await db.refresh(log)
 
     return log


### PR DESCRIPTION
## 概要
コードレビュー(Critical)で判明したトランザクション境界の問題を修正します。

`create_conversion_log` が `await db.commit()` でリクエスト途中にコミットしていましたが、`get_db`（`app/db/session.py`）も yield 後にコミットします。この二重コミットにより、**同一リクエスト内で CRUD が早期コミットすると、後続のDB操作との原子性が失われる**（CRUD分だけ先に確定し、後続が失敗してもロールバックされない）状態でした。

## 変更内容
- `app/crud/crud_ai_conversion.py`: `create_conversion_log` の `await db.commit()` を `await db.flush()` に変更。
  - コミットはリクエスト境界（`get_db`）に一元化。
  - `flush` で主キーが採番され、`refresh` 済みの返却オブジェクトは引き続き利用可能。

## テスト
- ログ記録テスト（実DB使用の tc401〜tc404, regenerate tc901）含め **278 passed, 5 skipped**。
- テストの依存性オーバーライド（`override_get_db`）はリクエスト末尾でコミットするため、別セッションからのログ参照は引き続き機能します。
- ruff / black クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)