### PR TITLE
修正: 履歴・お気に入り・定型文のHive永続化を配線（再起動でのデータ消失を解消）

### DIFF
--- a/frontend/kotonoha_app/lib/features/favorite/data/favorite_repository.dart
+++ b/frontend/kotonoha_app/lib/features/favorite/data/favorite_repository.dart
@@ -48,6 +48,12 @@ class FavoriteRepository {
     return _getSortedFavorites();
   }
 
+  /// 【メソッド定義】: 全お気に入りを同期的に読み込み（displayOrder昇順）
+  /// 【実装内容】: build()等の同期コンテキストから利用するためのバージョン
+  /// 【戻り値】: `List<FavoriteItem>`（displayOrder昇順）
+  /// 🔵 信頼性レベル: 青信号 - Notifier.build()での初期化に使用
+  List<FavoriteItem> loadAllSortedSync() => _getSortedFavorites();
+
   /// 【メソッド定義】: お気に入りを保存
   /// 【実装内容】: IDをキーとしてHive Boxに保存
   /// 【引数】: favorite - 保存するお気に入り

--- a/frontend/kotonoha_app/lib/features/favorite/providers/favorite_provider.dart
+++ b/frontend/kotonoha_app/lib/features/favorite/providers/favorite_provider.dart
@@ -4,6 +4,8 @@
 // 🔵 信頼性レベル: 青信号 - EARS要件定義書に基づく
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kotonoha_app/shared/models/favorite_item.dart';
+import 'package:kotonoha_app/shared/providers/repository_providers.dart';
 import 'package:uuid/uuid.dart';
 import '../domain/models/favorite.dart';
 
@@ -43,10 +45,38 @@ class FavoriteState {
 /// 🔵 信頼性レベル: 青信号 - REQ-701〜704に基づく
 class FavoriteNotifier extends Notifier<FavoriteState> {
   @override
-  FavoriteState build() => const FavoriteState();
+  FavoriteState build() {
+    // 【永続化配線】: Repositoryが利用可能（Boxオープン済み）の場合はHiveから初期化
+    // 【フォールバック】: repo==nilの場合は従来どおりインメモリ空状態
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo == null) return const FavoriteState();
+    return FavoriteState(
+      favorites: repo.loadAllSortedSync().map(_toDomain).toList(),
+    );
+  }
 
   /// UUID生成用インスタンス
   static const _uuid = Uuid();
+
+  /// 【変換ヘルパー】: Hiveモデル FavoriteItem → ドメイン Favorite
+  Favorite _toDomain(FavoriteItem item) => Favorite(
+        id: item.id,
+        content: item.content,
+        createdAt: item.createdAt,
+        displayOrder: item.displayOrder,
+        sourceType: item.sourceType,
+        sourceId: item.sourceId,
+      );
+
+  /// 【変換ヘルパー】: ドメイン Favorite → Hiveモデル FavoriteItem
+  FavoriteItem _toItem(Favorite f) => FavoriteItem(
+        id: f.id,
+        content: f.content,
+        createdAt: f.createdAt,
+        displayOrder: f.displayOrder,
+        sourceType: f.sourceType,
+        sourceId: f.sourceId,
+      );
 
   /// 【メソッド定義】: お気に入りを追加する
   /// 【実装内容】: テキストを受け取り、新しいお気に入りを追加
@@ -69,6 +99,12 @@ class FavoriteNotifier extends Notifier<FavoriteState> {
 
     final updatedFavorites = [...state.favorites, newFavorite];
     state = state.copyWith(favorites: updatedFavorites);
+
+    // 【永続化】: repoがあればHiveに保存
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      await repo.save(_toItem(newFavorite));
+    }
   }
 
   /// 【メソッド定義】: お気に入りを削除する
@@ -81,6 +117,12 @@ class FavoriteNotifier extends Notifier<FavoriteState> {
     final updatedFavorites = List<Favorite>.from(state.favorites);
     updatedFavorites.removeAt(index);
     state = state.copyWith(favorites: updatedFavorites);
+
+    // 【永続化】: repoがあればHiveから削除
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      await repo.delete(id);
+    }
   }
 
   /// 【メソッド定義】: お気に入りの並び順を変更する
@@ -105,14 +147,30 @@ class FavoriteNotifier extends Notifier<FavoriteState> {
     }).toList();
 
     state = state.copyWith(favorites: reorderedFavorites);
+
+    // 【永続化】: repoがあれば並び順を一括保存
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      for (final fav in reorderedFavorites) {
+        await repo.save(_toItem(fav));
+      }
+    }
   }
 
   /// 【メソッド定義】: お気に入りを読み込む
   /// 【実装内容】: ローカルストレージからお気に入りを読み込み
   /// 🟡 信頼性レベル: 黄信号 - 将来的にHiveから読み込み
   Future<void> loadFavorites() async {
-    // 現在はメモリ内での管理のみ
-    // 将来的にはHiveからの読み込みを実装（TASK-0059で対応）
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: Hiveからお気に入りを読み込み
+      state = state.copyWith(
+        favorites: repo.loadAllSortedSync().map(_toDomain).toList(),
+        isLoading: false,
+      );
+      return;
+    }
+    // 【フォールバック】: インメモリ管理のみ
     state = state.copyWith(isLoading: false);
   }
 
@@ -120,6 +178,11 @@ class FavoriteNotifier extends Notifier<FavoriteState> {
   /// 【実装内容】: 全てのお気に入りを削除
   /// 🔵 信頼性レベル: 青信号 - REQ-703（お気に入り削除）
   Future<void> clearAllFavorites() async {
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: Hiveの全お気に入りを削除
+      await repo.deleteAll();
+    }
     state = state.copyWith(favorites: []);
   }
 
@@ -152,6 +215,12 @@ class FavoriteNotifier extends Notifier<FavoriteState> {
     // 【状態更新】: Favoriteリストに追加
     final updatedFavorites = [...state.favorites, newFavorite];
     state = state.copyWith(favorites: updatedFavorites);
+
+    // 【永続化】: repoがあればHiveに保存（sourceType/sourceId含む）
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      await repo.save(_toItem(newFavorite));
+    }
   }
 
   /// 【メソッド定義】: sourceIdに一致するお気に入りを削除する
@@ -167,9 +236,16 @@ class FavoriteNotifier extends Notifier<FavoriteState> {
     if (index == -1) return;
 
     // 【削除処理】: 一致するFavoriteを削除
+    final removed = state.favorites[index];
     final updatedFavorites = List<Favorite>.from(state.favorites);
     updatedFavorites.removeAt(index);
     state = state.copyWith(favorites: updatedFavorites);
+
+    // 【永続化】: repoがあればHiveから削除
+    final repo = ref.read(favoriteRepositoryProvider);
+    if (repo != null) {
+      await repo.delete(removed.id);
+    }
   }
 }
 

--- a/frontend/kotonoha_app/lib/features/history/data/history_repository.dart
+++ b/frontend/kotonoha_app/lib/features/history/data/history_repository.dart
@@ -37,6 +37,12 @@ class HistoryRepository {
     return _getSortedHistories();
   }
 
+  /// 【メソッド定義】: 全履歴を同期的に読み込み（最新順）
+  /// 【実装内容】: build()等の同期コンテキストから利用するためのバージョン
+  /// 【戻り値】: `List<HistoryItem>`（最新順にソート）
+  /// 🔵 信頼性レベル: 青信号 - Notifier.build()での初期化に使用
+  List<HistoryItem> loadAllSortedSync() => _getSortedHistories();
+
   /// 【メソッド定義】: 履歴を保存（50件超過時は自動削除）
   /// 【実装内容】: IDをキーとしてHive Boxに保存、50件超過時は最古履歴を削除
   /// 【引数】: history - 保存する履歴

--- a/frontend/kotonoha_app/lib/features/history/providers/history_provider.dart
+++ b/frontend/kotonoha_app/lib/features/history/providers/history_provider.dart
@@ -4,6 +4,8 @@
 // 🔵 信頼性レベル: 青信号 - EARS要件定義書に基づく
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kotonoha_app/shared/models/history_item.dart';
+import 'package:kotonoha_app/shared/providers/repository_providers.dart';
 import 'package:uuid/uuid.dart';
 import '../domain/models/history.dart';
 import '../domain/models/history_type.dart';
@@ -44,10 +46,35 @@ class HistoryState {
 /// 🔵 信頼性レベル: 青信号 - REQ-601〜604に基づく
 class HistoryNotifier extends Notifier<HistoryState> {
   @override
-  HistoryState build() => const HistoryState();
+  HistoryState build() {
+    // 【永続化配線】: Repositoryが利用可能（Boxオープン済み）の場合はHiveから初期化
+    // 【フォールバック】: repo==nilの場合は従来どおりインメモリ空状態
+    final repo = ref.read(historyRepositoryProvider);
+    if (repo == null) return const HistoryState();
+    return HistoryState(
+      histories: repo.loadAllSortedSync().map(_toDomain).toList(),
+    );
+  }
 
   /// UUID生成用インスタンス
   static const _uuid = Uuid();
+
+  /// 【変換ヘルパー】: Hiveモデル HistoryItem → ドメイン History
+  History _toDomain(HistoryItem item) => History(
+        id: item.id,
+        content: item.content,
+        createdAt: item.createdAt,
+        type: HistoryType.values.byName(item.type),
+      );
+
+  /// 【変換ヘルパー】: ドメイン History → Hiveモデル HistoryItem
+  HistoryItem _toItem(History h) => HistoryItem(
+        id: h.id,
+        content: h.content,
+        createdAt: h.createdAt,
+        type: h.type.name,
+        isFavorite: false,
+      );
 
   /// 【メソッド定義】: 履歴を追加する
   /// 【実装内容】: テキストと種類を受け取り、新しい履歴を追加
@@ -64,7 +91,17 @@ class HistoryNotifier extends Notifier<HistoryState> {
       type: type,
     );
 
-    // 新しい履歴を先頭に追加（新しい順）
+    final repo = ref.read(historyRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: 保存後、Hiveから再読込（50件上限の自動削除を反映）
+      await repo.save(_toItem(newHistory));
+      state = state.copyWith(
+        histories: repo.loadAllSortedSync().map(_toDomain).toList(),
+      );
+      return;
+    }
+
+    // 【フォールバック】: 新しい履歴を先頭に追加（新しい順）
     final updatedHistories = [newHistory, ...state.histories];
     state = state.copyWith(histories: updatedHistories);
   }
@@ -73,6 +110,16 @@ class HistoryNotifier extends Notifier<HistoryState> {
   /// 【実装内容】: 指定IDの履歴を削除
   /// 🔵 信頼性レベル: 青信号 - REQ-603（履歴の削除）
   Future<void> deleteHistory(String id) async {
+    final repo = ref.read(historyRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: Hiveから削除後、再読込
+      await repo.delete(id);
+      state = state.copyWith(
+        histories: repo.loadAllSortedSync().map(_toDomain).toList(),
+      );
+      return;
+    }
+
     final index = state.histories.indexWhere((h) => h.id == id);
     if (index == -1) return;
 
@@ -94,8 +141,16 @@ class HistoryNotifier extends Notifier<HistoryState> {
   /// 【実装内容】: ローカルストレージから履歴を読み込み
   /// 🟡 信頼性レベル: 黄信号 - 将来的にHiveから読み込み
   Future<void> loadHistories() async {
-    // 現在はメモリ内での管理のみ
-    // 将来的にはHiveからの読み込みを実装（TASK-0059で対応）
+    final repo = ref.read(historyRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: Hiveから履歴を読み込み
+      state = state.copyWith(
+        histories: repo.loadAllSortedSync().map(_toDomain).toList(),
+        isLoading: false,
+      );
+      return;
+    }
+    // 【フォールバック】: インメモリ管理のみ
     state = state.copyWith(isLoading: false);
   }
 
@@ -103,6 +158,11 @@ class HistoryNotifier extends Notifier<HistoryState> {
   /// 【実装内容】: 全ての履歴を削除
   /// 🔵 信頼性レベル: 青信号 - REQ-603（履歴の削除）
   Future<void> clearAllHistories() async {
+    final repo = ref.read(historyRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: Hiveの全履歴を削除
+      await repo.deleteAll();
+    }
     state = state.copyWith(histories: []);
   }
 }

--- a/frontend/kotonoha_app/lib/features/preset_phrase/data/preset_phrase_repository.dart
+++ b/frontend/kotonoha_app/lib/features/preset_phrase/data/preset_phrase_repository.dart
@@ -28,14 +28,29 @@ class PresetPhraseRepository {
   /// 【パフォーマンス】: 2回目以降の読み込みは10ms以内（TASK-0090）
   /// 🔵 信頼性レベル: 青信号 - REQ-104、EDGE-104対応、NFR-004パフォーマンス要件
   Future<List<PresetPhrase>> loadAll() async {
-    // キャッシュがあればそれを返す（高速）
+    // キャッシュがあればそれを返す（高速、防御的コピー）
     if (_cache != null) {
-      return _cache!;
+      return List<PresetPhrase>.from(_cache!);
     }
 
     // キャッシュがなければHiveから読み込んでキャッシュする
     _cache = _box.values.toList();
-    return _cache!;
+    // 内部キャッシュの参照を直接返さず、防御的コピーを返す
+    return List<PresetPhrase>.from(_cache!);
+  }
+
+  /// 【メソッド定義】: 全定型文を同期的に読み込み
+  /// 【実装内容】: build()等の同期コンテキストから利用するためのバージョン
+  /// 【戻り値】: `List<PresetPhrase>`（防御的コピー、0件の場合は空リスト）
+  /// 🔵 信頼性レベル: 青信号 - Notifier.build()での初期化に使用
+  List<PresetPhrase> loadAllSync() => List<PresetPhrase>.from(_box.values);
+
+  /// 【メソッド定義】: 全定型文を削除
+  /// 【実装内容】: Hive Boxの全データをクリアしてキャッシュを無効化
+  /// 🔵 信頼性レベル: 青信号 - resetToDefaults用
+  Future<void> deleteAll() async {
+    await _box.clear();
+    invalidateCache();
   }
 
   /// 【メソッド定義】: 定型文を保存（追加・更新）

--- a/frontend/kotonoha_app/lib/features/preset_phrase/providers/preset_phrase_notifier.dart
+++ b/frontend/kotonoha_app/lib/features/preset_phrase/providers/preset_phrase_notifier.dart
@@ -224,11 +224,20 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
   }
 
   /// 【メソッド】: 定型文一覧を読み込む
-  /// 【実装内容】: ローカルストレージから定型文を読み込み
+  /// 【実装内容】: Hive（Boxオープン時）から定型文を読み込み、お気に入り順で反映
+  /// 【フォールバック】: repo==nilの場合は従来どおりインメモリ管理のみ
   /// 🔵 信頼性レベル: 青信号 - CRUD-205に基づく
   Future<void> loadPhrases() async {
-    // 現在はメモリ内での管理のみ
-    // 将来的にはHiveからの読み込みを実装
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      // 【永続化】: Hiveから読み込み、お気に入り順でソートして反映
+      state = state.copyWith(
+        phrases: _sortPhrases(repo.loadAllSync()),
+        isLoading: false,
+      );
+      return;
+    }
+    // 【フォールバック】: インメモリ管理のみ
     state = state.copyWith(isLoading: false);
   }
 

--- a/frontend/kotonoha_app/lib/features/preset_phrase/providers/preset_phrase_notifier.dart
+++ b/frontend/kotonoha_app/lib/features/preset_phrase/providers/preset_phrase_notifier.dart
@@ -19,6 +19,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kotonoha_app/features/favorite/providers/favorite_provider.dart';
 import 'package:kotonoha_app/features/preset_phrase/data/default_phrases.dart';
 import 'package:kotonoha_app/shared/models/preset_phrase.dart';
+import 'package:kotonoha_app/shared/providers/repository_providers.dart';
 import 'package:uuid/uuid.dart';
 
 /// 【状態管理】: 定型文一覧の状態
@@ -69,6 +70,16 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
   @override
   PresetPhraseState build() {
     _favoriteNotifier = ref.read(favoriteProvider.notifier);
+
+    // 【永続化配線】: Repositoryが利用可能（Boxオープン済み）の場合はHiveから初期化
+    // 【フォールバック】: repo==nilまたはデータ無しの場合は従来どおり空状態
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      final items = repo.loadAllSync();
+      if (items.isNotEmpty) {
+        return PresetPhraseState(phrases: _sortPhrases(items));
+      }
+    }
     return const PresetPhraseState();
   }
 
@@ -94,6 +105,12 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
     // 状態を更新し、お気に入り順でソート (REQ-105)
     final updatedPhrases = [...state.phrases, newPhrase];
     state = state.copyWith(phrases: _sortPhrases(updatedPhrases));
+
+    // 【永続化】: repoがあればHiveに保存
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      await repo.save(newPhrase);
+    }
   }
 
   /// 【メソッド】: 定型文を更新する
@@ -124,6 +141,12 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
     final updatedPhrases = List<PresetPhrase>.from(state.phrases);
     updatedPhrases[index] = updatedPhrase;
     state = state.copyWith(phrases: _sortPhrases(updatedPhrases));
+
+    // 【永続化】: repoがあればHiveに保存
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      await repo.save(updatedPhrase);
+    }
   }
 
   /// 【メソッド】: 定型文を削除する
@@ -148,6 +171,12 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
     final updatedPhrases = List<PresetPhrase>.from(state.phrases);
     updatedPhrases.removeAt(index);
     state = state.copyWith(phrases: updatedPhrases);
+
+    // 【永続化】: repoがあればHiveから削除
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      await repo.delete(id);
+    }
   }
 
   /// 【メソッド】: お気に入りを切り替える
@@ -170,6 +199,12 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
     updatedPhrases[index] = updatedPhrase;
     // お気に入り順でソート (REQ-105)
     state = state.copyWith(phrases: _sortPhrases(updatedPhrases));
+
+    // 【永続化】: repoがあればHiveに保存（isFavoriteフラグの変更を反映）
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      await repo.save(updatedPhrase);
+    }
 
     // 【連動処理】: FavoriteNotifierへの連動（TC-SYNC-001, TC-SYNC-002）
     // 【処理方針】: お気に入り追加時はFavoriteにも追加、解除時はFavoriteからも削除
@@ -234,6 +269,12 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
         }
       }
 
+      // 【永続化】: repoがあればHiveに一括保存
+      final repo = ref.read(presetPhraseRepositoryProvider);
+      if (repo != null) {
+        await repo.saveAll(phrases);
+      }
+
       state = state.copyWith(
         phrases: phrases,
         isLoading: false,
@@ -252,6 +293,11 @@ class PresetPhraseNotifier extends Notifier<PresetPhraseState> {
   ///
   /// 設定画面等から呼び出され、定型文を初期状態に戻す。
   Future<void> resetToDefaults() async {
+    // 【永続化】: repoがあればHiveの定型文を全削除してから再投入
+    final repo = ref.read(presetPhraseRepositoryProvider);
+    if (repo != null) {
+      await repo.deleteAll();
+    }
     state = state.copyWith(phrases: [], isLoading: true);
     await initializeDefaultPhrases();
   }

--- a/frontend/kotonoha_app/lib/shared/models/favorite_item.dart
+++ b/frontend/kotonoha_app/lib/shared/models/favorite_item.dart
@@ -30,6 +30,18 @@ class FavoriteItem extends HiveObject {
   @HiveField(3)
   final int displayOrder;
 
+  /// 【フィールド定義】: 元データの種類（'preset_phrase' | 'history' | null）
+  /// 【実装内容】: お気に入りの由来を保持（定型文連動の永続化に使用）
+  /// 🟡 信頼性レベル: 黄信号 - TDD-FAVORITE-SYNC要件に基づく拡張
+  @HiveField(4)
+  final String? sourceType;
+
+  /// 【フィールド定義】: 元データのID（定型文IDまたは履歴ID）
+  /// 【実装内容】: 連動元のIDを保持（定型文連動の永続化に使用）
+  /// 🟡 信頼性レベル: 黄信号 - TDD-FAVORITE-SYNC要件に基づく拡張
+  @HiveField(5)
+  final String? sourceId;
+
   /// 【コンストラクタ】: FavoriteItem生成
   /// 【実装内容】: 全フィールドを初期化
   /// 🔵 信頼性レベル: 青信号 - テストケースTC-065-001〜TC-065-005の要件に基づく
@@ -38,6 +50,8 @@ class FavoriteItem extends HiveObject {
     required this.content,
     required this.createdAt,
     required this.displayOrder,
+    this.sourceType,
+    this.sourceId,
   });
 
   /// 【copyWithメソッド】: 不変オブジェクトの部分更新
@@ -49,12 +63,16 @@ class FavoriteItem extends HiveObject {
     String? content,
     DateTime? createdAt,
     int? displayOrder,
+    String? sourceType,
+    String? sourceId,
   }) {
     return FavoriteItem(
       id: id ?? this.id,
       content: content ?? this.content,
       createdAt: createdAt ?? this.createdAt,
       displayOrder: displayOrder ?? this.displayOrder,
+      sourceType: sourceType ?? this.sourceType,
+      sourceId: sourceId ?? this.sourceId,
     );
   }
 
@@ -82,6 +100,6 @@ class FavoriteItem extends HiveObject {
   /// 🔵 信頼性レベル: 青信号 - デバッグ・ログ出力のため
   @override
   String toString() {
-    return 'FavoriteItem(id: $id, content: $content, createdAt: $createdAt, displayOrder: $displayOrder)';
+    return 'FavoriteItem(id: $id, content: $content, createdAt: $createdAt, displayOrder: $displayOrder, sourceType: $sourceType, sourceId: $sourceId)';
   }
 }

--- a/frontend/kotonoha_app/lib/shared/models/favorite_item_adapter.dart
+++ b/frontend/kotonoha_app/lib/shared/models/favorite_item_adapter.dart
@@ -12,6 +12,8 @@ import 'package:kotonoha_app/shared/models/favorite_item.dart';
 /// - 1: content (String)
 /// - 2: createdAt (DateTime)
 /// - 3: displayOrder (int)
+/// - 4: sourceType (String?)
+/// - 5: sourceId (String?)
 ///
 /// 🔵 信頼性レベル: 青信号 - REQ-701、FR-065-001に基づく
 class FavoriteItemAdapter extends TypeAdapter<FavoriteItem> {
@@ -29,13 +31,16 @@ class FavoriteItemAdapter extends TypeAdapter<FavoriteItem> {
       content: fields[1] as String,
       createdAt: fields[2] as DateTime,
       displayOrder: fields[3] as int,
+      // 後方互換: 既存データにフィールドが無い場合はnullになる（fieldsマップ方式）
+      sourceType: fields[4] as String?,
+      sourceId: fields[5] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, FavoriteItem obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(6)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -43,7 +48,11 @@ class FavoriteItemAdapter extends TypeAdapter<FavoriteItem> {
       ..writeByte(2)
       ..write(obj.createdAt)
       ..writeByte(3)
-      ..write(obj.displayOrder);
+      ..write(obj.displayOrder)
+      ..writeByte(4)
+      ..write(obj.sourceType)
+      ..writeByte(5)
+      ..write(obj.sourceId);
   }
 
   @override

--- a/frontend/kotonoha_app/lib/shared/providers/repository_providers.dart
+++ b/frontend/kotonoha_app/lib/shared/providers/repository_providers.dart
@@ -1,0 +1,42 @@
+/// 【Provider定義】: Hiveリポジトリの提供（永続化配線）
+///
+/// 【設計判断】: nullフォールバック方式
+/// - 対応するHive Boxがオープン済みの場合のみRepositoryインスタンスを返す。
+/// - Hive未初期化・Box未オープンの場合はnullを返す。
+/// - これにより、Hiveを初期化しない素のProviderContainer()を使う既存テスト
+///   （例: favorite_sync_test）は repo==null となり、Notifierが従来どおり
+///   インメモリ動作にフォールバックできる。
+/// - Hive.isBoxOpen() は Hive.init 未実行でも例外を投げずに false を返す。
+///
+/// 🔵 信頼性レベル: 青信号 - architecture.mdのローカルストレージ設計に基づく
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:kotonoha_app/features/favorite/data/favorite_repository.dart';
+import 'package:kotonoha_app/features/history/data/history_repository.dart';
+import 'package:kotonoha_app/features/preset_phrase/data/preset_phrase_repository.dart';
+import 'package:kotonoha_app/shared/models/favorite_item.dart';
+import 'package:kotonoha_app/shared/models/history_item.dart';
+import 'package:kotonoha_app/shared/models/preset_phrase.dart';
+
+/// 【Provider定義】: 履歴Repository（Box未オープン時はnull）
+final historyRepositoryProvider = Provider<HistoryRepository?>(
+  (ref) => Hive.isBoxOpen('history')
+      ? HistoryRepository(box: Hive.box<HistoryItem>('history'))
+      : null,
+);
+
+/// 【Provider定義】: お気に入りRepository（Box未オープン時はnull）
+final favoriteRepositoryProvider = Provider<FavoriteRepository?>(
+  (ref) => Hive.isBoxOpen('favorites')
+      ? FavoriteRepository(box: Hive.box<FavoriteItem>('favorites'))
+      : null,
+);
+
+/// 【Provider定義】: 定型文Repository（Box未オープン時はnull）
+final presetPhraseRepositoryProvider = Provider<PresetPhraseRepository?>(
+  (ref) => Hive.isBoxOpen('presetPhrases')
+      ? PresetPhraseRepository(box: Hive.box<PresetPhrase>('presetPhrases'))
+      : null,
+);

--- a/frontend/kotonoha_app/test/features/data_persistence/persistence_wiring_test.dart
+++ b/frontend/kotonoha_app/test/features/data_persistence/persistence_wiring_test.dart
@@ -1,0 +1,233 @@
+/// 永続化配線テスト（履歴・お気に入り・定型文のHive結線）
+///
+/// fix/frontend-persistence-wiring:
+/// - Notifierの各操作がHive Boxに永続化され、アプリ再起動相当（新しい
+///   ProviderContainer）でデータが復元されることを検証する。
+/// - リポジトリProviderがBox未オープン時にnullを返すことを検証する。
+///
+/// 設計判断（nullフォールバック方式）:
+/// - Hiveを初期化しない素のProviderContainer()では repo==null となり、
+///   Notifierはインメモリ動作にフォールバックする。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:kotonoha_app/features/favorite/providers/favorite_provider.dart';
+import 'package:kotonoha_app/features/history/domain/models/history_type.dart';
+import 'package:kotonoha_app/features/history/providers/history_provider.dart';
+import 'package:kotonoha_app/features/preset_phrase/providers/preset_phrase_notifier.dart';
+import 'package:kotonoha_app/shared/models/favorite_item.dart';
+import 'package:kotonoha_app/shared/models/favorite_item_adapter.dart';
+import 'package:kotonoha_app/shared/models/history_item.dart';
+import 'package:kotonoha_app/shared/models/history_item_adapter.dart';
+import 'package:kotonoha_app/shared/models/preset_phrase.dart';
+import 'package:kotonoha_app/shared/models/preset_phrase_adapter.dart';
+import 'package:kotonoha_app/shared/providers/repository_providers.dart';
+
+void main() {
+  group('永続化配線 - Hive初期化済み環境', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      // 【テスト前準備】: 一時ディレクトリでHiveを初期化し、本番と同じ名前の
+      // ボックスをオープンする（Providerが 'history'/'favorites'/'presetPhrases'
+      // を参照するため）。
+      await Hive.close();
+      tempDir = await Directory.systemTemp.createTemp('hive_wiring_test_');
+      Hive.init(tempDir.path);
+
+      if (!Hive.isAdapterRegistered(0)) {
+        Hive.registerAdapter(HistoryItemAdapter());
+      }
+      if (!Hive.isAdapterRegistered(1)) {
+        Hive.registerAdapter(PresetPhraseAdapter());
+      }
+      if (!Hive.isAdapterRegistered(2)) {
+        Hive.registerAdapter(FavoriteItemAdapter());
+      }
+
+      await Hive.openBox<HistoryItem>('history');
+      await Hive.openBox<PresetPhrase>('presetPhrases');
+      await Hive.openBox<FavoriteItem>('favorites');
+    });
+
+    tearDown(() async {
+      // 【テスト後処理】: 全ボックスをクローズし、ディスクから削除
+      await Hive.deleteBoxFromDisk('history');
+      await Hive.deleteBoxFromDisk('presetPhrases');
+      await Hive.deleteBoxFromDisk('favorites');
+      await Hive.close();
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('履歴を追加すると新しいコンテナで復元される', () async {
+      final container1 = ProviderContainer();
+      await container1
+          .read(historyProvider.notifier)
+          .addHistory('こんにちは', HistoryType.manualInput);
+      // 念のためもう1件（種類が異なる）
+      await container1
+          .read(historyProvider.notifier)
+          .addHistory('ありがとう', HistoryType.aiConverted);
+      container1.dispose();
+
+      // 【再起動相当】: 同じBoxを使う新しいコンテナで初期化
+      final container2 = ProviderContainer();
+      final state = container2.read(historyProvider);
+      container2.dispose();
+
+      expect(state.histories.length, 2);
+      final contents = state.histories.map((h) => h.content).toSet();
+      expect(contents, containsAll(<String>['こんにちは', 'ありがとう']));
+      // typeが正しく復元されること
+      final greeting = state.histories.firstWhere((h) => h.content == 'こんにちは');
+      expect(greeting.type, HistoryType.manualInput);
+      final ai = state.histories.firstWhere((h) => h.content == 'ありがとう');
+      expect(ai.type, HistoryType.aiConverted);
+    });
+
+    test('履歴削除が永続化される', () async {
+      final container1 = ProviderContainer();
+      await container1
+          .read(historyProvider.notifier)
+          .addHistory('削除対象', HistoryType.manualInput);
+      final id = container1.read(historyProvider).histories.first.id;
+      await container1.read(historyProvider.notifier).deleteHistory(id);
+      container1.dispose();
+
+      final container2 = ProviderContainer();
+      final state = container2.read(historyProvider);
+      container2.dispose();
+
+      expect(state.histories, isEmpty);
+    });
+
+    test('お気に入りを追加すると新しいコンテナで復元される', () async {
+      final container1 = ProviderContainer();
+      await container1.read(favoriteProvider.notifier).addFavorite('お気に入り1');
+      await container1.read(favoriteProvider.notifier).addFavorite('お気に入り2');
+      container1.dispose();
+
+      final container2 = ProviderContainer();
+      final state = container2.read(favoriteProvider);
+      container2.dispose();
+
+      expect(state.favorites.length, 2);
+      expect(
+        state.favorites.map((f) => f.content).toList(),
+        ['お気に入り1', 'お気に入り2'],
+      );
+    });
+
+    test('定型文を追加すると新しいコンテナで復元される', () async {
+      final container1 = ProviderContainer();
+      await container1
+          .read(presetPhraseNotifierProvider.notifier)
+          .addPhrase('テスト定型文', 'daily');
+      container1.dispose();
+
+      final container2 = ProviderContainer();
+      final state = container2.read(presetPhraseNotifierProvider);
+      container2.dispose();
+
+      expect(state.phrases.length, 1);
+      expect(state.phrases.first.content, 'テスト定型文');
+      expect(state.phrases.first.category, 'daily');
+    });
+
+    test('定型文のお気に入り連動でsourceId付きFavoriteが永続化・復元される', () async {
+      final container1 = ProviderContainer();
+      final presetNotifier =
+          container1.read(presetPhraseNotifierProvider.notifier);
+      await presetNotifier.addPhrase('連動定型文', 'daily');
+      final phraseId =
+          container1.read(presetPhraseNotifierProvider).phrases.first.id;
+      // お気に入りON → FavoriteNotifierへ連動 → 永続化
+      await presetNotifier.toggleFavorite(phraseId);
+      container1.dispose();
+
+      // 【再起動相当】: 新しいコンテナでFavoriteを確認
+      final container2 = ProviderContainer();
+      final favState = container2.read(favoriteProvider);
+      container2.dispose();
+
+      expect(favState.favorites.length, 1);
+      final fav = favState.favorites.first;
+      expect(fav.content, '連動定型文');
+      expect(fav.sourceType, 'preset_phrase');
+      expect(fav.sourceId, phraseId);
+    });
+
+    test('initializeDefaultPhrasesが永続化され新しいコンテナで復元される', () async {
+      final container1 = ProviderContainer();
+      await container1
+          .read(presetPhraseNotifierProvider.notifier)
+          .initializeDefaultPhrases();
+      final count1 = container1.read(presetPhraseNotifierProvider).phrases.length;
+      container1.dispose();
+
+      expect(count1, greaterThan(0));
+
+      final container2 = ProviderContainer();
+      final state = container2.read(presetPhraseNotifierProvider);
+      container2.dispose();
+
+      expect(state.phrases.length, count1);
+    });
+
+    test('clearAllHistoriesがHiveの履歴を全削除する', () async {
+      final container1 = ProviderContainer();
+      await container1
+          .read(historyProvider.notifier)
+          .addHistory('a', HistoryType.manualInput);
+      await container1.read(historyProvider.notifier).clearAllHistories();
+      container1.dispose();
+
+      final container2 = ProviderContainer();
+      final state = container2.read(historyProvider);
+      container2.dispose();
+
+      expect(state.histories, isEmpty);
+    });
+
+    test('リポジトリProviderはBoxオープン時に非nullを返す', () {
+      final container = ProviderContainer();
+      expect(container.read(historyRepositoryProvider), isNotNull);
+      expect(container.read(favoriteRepositoryProvider), isNotNull);
+      expect(container.read(presetPhraseRepositoryProvider), isNotNull);
+      container.dispose();
+    });
+  });
+
+  group('永続化配線 - Hive未初期化環境（nullフォールバック）', () {
+    setUp(() async {
+      // 【前提】: 全ボックスを閉じてオープンされていない状態にする
+      await Hive.close();
+    });
+
+    test('リポジトリProviderはBox未オープン時にnullを返す', () {
+      final container = ProviderContainer();
+      expect(container.read(historyRepositoryProvider), isNull);
+      expect(container.read(favoriteRepositoryProvider), isNull);
+      expect(container.read(presetPhraseRepositoryProvider), isNull);
+      container.dispose();
+    });
+
+    test('repo==nullでもインメモリで履歴追加が動作する', () async {
+      final container = ProviderContainer();
+      await container
+          .read(historyProvider.notifier)
+          .addHistory('インメモリ', HistoryType.manualInput);
+      final state = container.read(historyProvider);
+      container.dispose();
+
+      expect(state.histories.length, 1);
+      expect(state.histories.first.content, 'インメモリ');
+    });
+  });
+}

--- a/frontend/kotonoha_app/test/features/data_persistence/persistence_wiring_test.dart
+++ b/frontend/kotonoha_app/test/features/data_persistence/persistence_wiring_test.dart
@@ -168,7 +168,8 @@ void main() {
       await container1
           .read(presetPhraseNotifierProvider.notifier)
           .initializeDefaultPhrases();
-      final count1 = container1.read(presetPhraseNotifierProvider).phrases.length;
+      final count1 =
+          container1.read(presetPhraseNotifierProvider).phrases.length;
       container1.dispose();
 
       expect(count1, greaterThan(0));

--- a/frontend/kotonoha_app/test/features/data_persistence/persistence_wiring_test.dart
+++ b/frontend/kotonoha_app/test/features/data_persistence/persistence_wiring_test.dart
@@ -180,6 +180,35 @@ void main() {
       expect(state.phrases.length, count1);
     });
 
+    test('loadPhrasesがHiveから定型文をstateに再読込する', () async {
+      // 別経路でBoxに直接保存（Notifier未経由の保存をシミュレート）
+      final box = Hive.box<PresetPhrase>('presetPhrases');
+      final now = DateTime.now();
+      await box.put(
+        'p1',
+        PresetPhrase(
+          id: 'p1',
+          content: '保存済み定型文',
+          category: 'daily',
+          isFavorite: false,
+          displayOrder: 0,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(presetPhraseNotifierProvider.notifier);
+
+      // loadPhrases() でHiveから再読込され、stateに反映される
+      await notifier.loadPhrases();
+      final state = container.read(presetPhraseNotifierProvider);
+
+      expect(state.isLoading, isFalse);
+      expect(state.phrases.map((p) => p.content), contains('保存済み定型文'));
+    });
+
     test('clearAllHistoriesがHiveの履歴を全削除する', () async {
       final container1 = ProviderContainer();
       await container1


### PR DESCRIPTION
## 概要
コードレビュー(Critical)で判明した、**履歴・お気に入り・定型文がアプリ再起動で消失する**問題を修正します。

リポジトリ層（Hive）は実装済みでしたが Provider に結線されておらず、各 Notifier はメモリ管理のみでした（コード内に「将来的にHiveから読み込み（TASK-0059）」のTODOが残存）。これによりオフラインファースト・端末内保存というコア要件（REQ-601/REQ-104/REQ-701 等）が満たされていませんでした。

## 設計：既存テストを壊さない安全な配線
- 新設 `lib/shared/providers/repository_providers.dart`：対応する Hive Box が**未オープンのときは `null` を返す** nullable なリポジトリ Provider。
- 各 Notifier は `repo == null` のとき従来どおりインメモリ動作にフォールバック。Hive を初期化しない素の `ProviderContainer()` を使う既存テスト（favorite_sync_test 等）はそのまま通ります。
- 実アプリは `main()` の `initHive()` で Box がオープン済みのため、`build()` が Box から同期ロードして自動復元します。

## 変更内容
- `history_provider.dart` / `favorite_provider.dart` / `preset_phrase_notifier.dart`：build・add・update・delete・toggle・reorder・load・clear・initialize をリポジトリ経由の読み書きに結線。
- ドメイン↔Hive モデル変換ヘルパーを追加（`History`↔`HistoryItem` 等。enum 名で対応）。
- `FavoriteItem` に `sourceType`/`sourceId`（`@HiveField(4)(5)`, nullable）を追加し手書きアダプタを更新（後方互換）。定型文連動お気に入りの `sourceId` を永続化するため。
- `PresetPhraseRepository` に `deleteAll()` を追加、`loadAll()` のキャッシュを防御的コピーに修正。
- 各リポジトリに `build()` 用の同期読み取りメソッドを追加。

## テスト
- 追加 `test/features/data_persistence/persistence_wiring_test.dart`（永続化・別コンテナ復元・sourceId 復元・Box未オープン時のnullフォールバック等）。
- `flutter test`: **All tests passed!（1451件）**、`flutter analyze` 変更ファイル指摘ゼロ。
- `pubspec.lock` はCIが各環境で解決するため本PRには含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)