### PR TITLE
修正: ネットワーク監視の起動と緊急機能の全画面配線（ShellRoute導入）

### DIFF
--- a/frontend/kotonoha_app/lib/core/router/app_router.dart
+++ b/frontend/kotonoha_app/lib/core/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:kotonoha_app/core/router/error_screen.dart';
+import 'package:kotonoha_app/core/widgets/app_shell.dart';
 import 'package:kotonoha_app/features/character_board/presentation/home_screen.dart';
 import 'package:kotonoha_app/features/favorites/presentation/favorites_screen.dart';
 import 'package:kotonoha_app/features/help/presentation/screens/help_screen.dart';
@@ -47,39 +48,52 @@ abstract final class AppRoutes {
 /// - FR-003: 4つの主要ルート定義（home, settings, history, favorites）
 /// - FR-004: errorBuilderでエラー画面を設定
 /// - FR-006: MaterialApp.routerとの統合
+///
+/// ## ShellRoute採用
+///
+/// 全6ルートを単一の [ShellRoute] で内包する。ShellRouteのbuilderは
+/// [AppShell] を返し、全画面共通の横断的関心事（ネットワーク監視の起動・
+/// 緊急機能の全画面配線）を一箇所で配線する。
+/// ShellRouteのchildはShell配下のNavigatorに属するため、緊急ボタンの
+/// 確認ダイアログ（Navigator.of(context)を使用）が正しく動作する。
 final routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     initialLocation: AppRoutes.home,
     routes: [
-      GoRoute(
-        path: AppRoutes.home,
-        name: 'home',
-        builder: (context, state) => const HomeScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.settings,
-        name: 'settings',
-        builder: (context, state) => const SettingsScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.history,
-        name: 'history',
-        builder: (context, state) => const HistoryScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.favorites,
-        name: 'favorites',
-        builder: (context, state) => const FavoritesScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.help,
-        name: 'help',
-        builder: (context, state) => const HelpScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.presetPhrases,
-        name: 'presetPhrases',
-        builder: (context, state) => const PresetPhraseScreen(),
+      ShellRoute(
+        builder: (context, state, child) => AppShell(child: child),
+        routes: [
+          GoRoute(
+            path: AppRoutes.home,
+            name: 'home',
+            builder: (context, state) => const HomeScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.settings,
+            name: 'settings',
+            builder: (context, state) => const SettingsScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.history,
+            name: 'history',
+            builder: (context, state) => const HistoryScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.favorites,
+            name: 'favorites',
+            builder: (context, state) => const FavoritesScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.help,
+            name: 'help',
+            builder: (context, state) => const HelpScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.presetPhrases,
+            name: 'presetPhrases',
+            builder: (context, state) => const PresetPhraseScreen(),
+          ),
+        ],
       ),
     ],
     errorBuilder: (context, state) => ErrorScreen(error: state.error),

--- a/frontend/kotonoha_app/lib/core/widgets/app_shell.dart
+++ b/frontend/kotonoha_app/lib/core/widgets/app_shell.dart
@@ -1,0 +1,114 @@
+/// アプリ全画面共通シェル
+///
+/// 全ルート画面を内包する共通シェル。go_routerのShellRouteから利用され、
+/// 以下の2つの横断的関心事を全画面に配線する。
+///
+/// 1. ネットワーク監視の起動（F2 / REQ-1001, REQ-3004）
+///    - 起動時に一度だけ NetworkNotifier を初期化し、接続状態の監視を開始する。
+///    - これにより `isAIConversionAvailable` がオンライン時に true となり、
+///      AI変換が利用可能になる。
+///
+/// 2. 緊急機能の全画面配線（F3 / REQ-301, REQ-302, REQ-304）
+///    - 右下に緊急ボタンを常時表示（REQ-301）。
+///    - 緊急状態（alertActive）の時に緊急アラート画面を最前面に重ねる（REQ-304）。
+///
+/// 信頼性レベル: 🔵 青信号（要件定義書ベース）
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:kotonoha_app/features/emergency/domain/models/emergency_state.dart';
+import 'package:kotonoha_app/features/emergency/presentation/providers/emergency_state_provider.dart';
+import 'package:kotonoha_app/features/emergency/presentation/screens/emergency_alert_screen.dart';
+import 'package:kotonoha_app/features/emergency/presentation/widgets/emergency_button_with_confirmation.dart';
+import 'package:kotonoha_app/features/network/providers/network_provider.dart';
+
+/// 全画面共通シェルウィジェット
+///
+/// ShellRouteのbuilderから `AppShell(child: child)` として生成される。
+/// [child] は現在のルート画面ウィジェット。
+class AppShell extends ConsumerStatefulWidget {
+  /// 現在表示中のルート画面
+  final Widget child;
+
+  /// AppShellを作成する。
+  ///
+  /// [child] - ShellRouteから渡される現在のルート画面（必須）
+  const AppShell({super.key, required this.child});
+
+  @override
+  ConsumerState<AppShell> createState() => _AppShellState();
+}
+
+class _AppShellState extends ConsumerState<AppShell> {
+  /// ネットワーク監視の起動を一度きりにするためのフラグ
+  bool _networkInitialized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // 最初のフレーム描画後にネットワーク監視を起動する（F2）。
+    // initState内で直接ref.readを呼ばず、addPostFrameCallbackで遅延実行する。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeNetworkMonitoring();
+    });
+  }
+
+  /// ネットワーク監視を起動する（一度きり）
+  ///
+  /// 初期接続状態の確認と接続状態変更リスナーの開始を行う。
+  /// connectivity_plusプラグインが未モックなテスト環境などでも
+  /// テストが落ちないよう、例外は握りつぶす
+  /// （NetworkNotifier側でも捕捉済み）。
+  Future<void> _initializeNetworkMonitoring() async {
+    if (_networkInitialized) return;
+    _networkInitialized = true;
+
+    try {
+      final notifier = ref.read(networkProvider.notifier);
+      await notifier.initializeWithConnectivity();
+      await notifier.startListening();
+    } catch (_) {
+      // テスト環境などでのプラグイン未モック対策。
+      // ネットワーク状態は checking のままとなり、AI変換は無効のままになる。
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 緊急状態を監視し、alertActive時に緊急画面を最前面に重ねる（REQ-304）
+    final emergencyState = ref.watch(emergencyStateProvider);
+    final isAlertActive = emergencyState == EmergencyStateEnum.alertActive;
+
+    return Stack(
+      children: [
+        // 現在のルート画面
+        widget.child,
+
+        // 緊急ボタン（全画面常時表示 / REQ-301, REQ-302）
+        SafeArea(
+          child: Align(
+            alignment: Alignment.bottomRight,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: EmergencyButtonWithConfirmation(
+                onEmergencyConfirmed: () =>
+                    ref.read(emergencyStateProvider.notifier).startEmergency(),
+              ),
+            ),
+          ),
+        ),
+
+        // 緊急アラート画面（alertActive時のみ最前面に表示 / REQ-304）
+        if (isAlertActive)
+          Positioned.fill(
+            child: EmergencyAlertScreen(
+              onReset: () =>
+                  ref.read(emergencyStateProvider.notifier).resetEmergency(),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/frontend/kotonoha_app/test/core/router/app_router_test.dart
+++ b/frontend/kotonoha_app/test/core/router/app_router_test.dart
@@ -54,7 +54,11 @@ void main() {
 
       // When（実行フェーズ）
       final router = container.read(routerProvider);
-      final routes = router.configuration.routes.whereType<GoRoute>().toList();
+      // ShellRoute導入により、GoRouteはShellRoute配下に定義される。
+      // ShellRouteの.routesからGoRouteを集計する。
+      final shellRoute =
+          router.configuration.routes.whereType<ShellRoute>().single;
+      final routes = shellRoute.routes.whereType<GoRoute>().toList();
 
       // Then（検証フェーズ）
       // ホームルート（/）が最初に定義されていることを確認
@@ -89,12 +93,23 @@ void main() {
 
       // When（実行フェーズ）
       final router = container.read(routerProvider);
-      final routes = router.configuration.routes;
+      // ShellRoute導入により、トップレベルには単一のShellRouteが存在し、
+      // 6つの主要ルートはそのShellRoute配下のGoRouteとして定義される。
+      final topRoutes = router.configuration.routes;
+      final shellRoute = topRoutes.whereType<ShellRoute>().single;
+      final goRoutes = shellRoute.routes.whereType<GoRoute>().toList();
 
       // Then（検証フェーズ）
-      // 6つの主要ルート（/, /settings, /history, /favorites, /help, /preset-phrases）が定義されていることを確認
+      // トップレベルは単一のShellRoute
       expect(
-        routes.length,
+        topRoutes.length,
+        equals(1),
+        reason: 'トップレベルは全画面共通シェル（ShellRoute）1つである必要がある',
+      );
+      // 6つの主要ルート（/, /settings, /history, /favorites, /help, /preset-phrases）が
+      // ShellRoute配下に定義されていることを確認
+      expect(
+        goRoutes.length,
         equals(6),
         reason:
             '主要ルートは6つ（home, settings, history, favorites, help, presetPhrases）である必要がある',
@@ -115,7 +130,10 @@ void main() {
 
       // When（実行フェーズ）
       final router = container.read(routerProvider);
-      final routes = router.configuration.routes.whereType<GoRoute>().toList();
+      // ShellRoute配下のGoRouteから名前を集計する。
+      final shellRoute =
+          router.configuration.routes.whereType<ShellRoute>().single;
+      final routes = shellRoute.routes.whereType<GoRoute>().toList();
       final routeNames = routes.map((r) => r.name).whereType<String>().toList();
 
       // Then（検証フェーズ）
@@ -159,12 +177,14 @@ void main() {
         reason: 'GoRouterのconfigurationが設定されている必要がある',
       );
 
-      // 全ルートがGoRoute型であることを確認
-      final routes = router.configuration.routes;
+      // ShellRoute配下のルートが全てGoRoute型であることを確認
+      final shellRoute =
+          router.configuration.routes.whereType<ShellRoute>().single;
+      final routes = shellRoute.routes;
       expect(
         routes.every((route) => route is GoRoute),
         isTrue,
-        reason: 'すべてのルートはGoRoute型である必要がある',
+        reason: 'ShellRoute配下のルートはすべてGoRoute型である必要がある',
       );
     });
   });

--- a/frontend/kotonoha_app/test/core/widgets/app_shell_network_test.dart
+++ b/frontend/kotonoha_app/test/core/widgets/app_shell_network_test.dart
@@ -97,8 +97,7 @@ void main() {
       );
     });
 
-    testWidgets('F2: 接続状態変更ストリームの更新が状態へ反映される',
-        (WidgetTester tester) async {
+    testWidgets('F2: 接続状態変更ストリームの更新が状態へ反映される', (WidgetTester tester) async {
       await tester.pumpWidget(
         UncontrolledProviderScope(
           container: container,

--- a/frontend/kotonoha_app/test/core/widgets/app_shell_network_test.dart
+++ b/frontend/kotonoha_app/test/core/widgets/app_shell_network_test.dart
@@ -1,0 +1,125 @@
+/// AppShell ネットワーク監視起動テスト
+///
+/// F2: AppShellがマウント時にネットワーク監視
+/// （initializeWithConnectivity / startListening）を起動することを検証する。
+/// これにより networkProvider の状態が checking から実際の接続状態へ更新され、
+/// isAIConversionAvailable がオンライン時に true となる。
+///
+/// 関連要件:
+/// - REQ-1001: オフライン時AI変換無効化
+/// - REQ-3004: ネットワーク状態の正確な検知
+library;
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:kotonoha_app/core/widgets/app_shell.dart';
+import 'package:kotonoha_app/features/emergency/presentation/providers/emergency_state_provider.dart';
+import 'package:kotonoha_app/features/network/domain/models/network_state.dart';
+import 'package:kotonoha_app/features/network/domain/services/connectivity_service.dart';
+import 'package:kotonoha_app/features/network/providers/network_provider.dart';
+
+import '../../mocks/mock_emergency_audio_service.dart';
+
+class MockConnectivityService extends Mock implements ConnectivityService {}
+
+void main() {
+  group('AppShell ネットワーク監視起動テスト', () {
+    late MockConnectivityService mockService;
+    late MockEmergencyAudioService mockAudioService;
+    late StreamController<List<ConnectivityResult>> connectivityController;
+    late ProviderContainer container;
+
+    setUp(() {
+      mockService = MockConnectivityService();
+      mockAudioService = MockEmergencyAudioService();
+      connectivityController =
+          StreamController<List<ConnectivityResult>>.broadcast();
+
+      when(() => mockService.onConnectivityChanged)
+          .thenAnswer((_) => connectivityController.stream);
+      when(() => mockService.checkConnectivity())
+          .thenAnswer((_) async => [ConnectivityResult.wifi]);
+      when(() => mockAudioService.startEmergencySound())
+          .thenAnswer((_) async {});
+      when(() => mockAudioService.stopEmergencySound())
+          .thenAnswer((_) async {});
+
+      container = ProviderContainer(
+        overrides: [
+          connectivityServiceProvider.overrideWithValue(mockService),
+          emergencyAudioServiceProvider.overrideWithValue(mockAudioService),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+      connectivityController.close();
+    });
+
+    testWidgets('F2: マウント時にネットワーク監視が起動しオンライン状態になる',
+        (WidgetTester tester) async {
+      // 初期状態は checking
+      expect(container.read(networkProvider), NetworkState.checking);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: AppShell(
+              child: Scaffold(body: Text('test child')),
+            ),
+          ),
+        ),
+      );
+      // post-frame callback 実行とネットワーク初期化の非同期完了を待つ
+      await tester.pumpAndSettle();
+
+      // initializeWithConnectivity / startListening が呼ばれた結果、
+      // checkConnectivity が実行され状態がオンラインへ更新される
+      verify(() => mockService.checkConnectivity()).called(1);
+      verify(() => mockService.onConnectivityChanged).called(greaterThan(0));
+      expect(
+        container.read(networkProvider),
+        NetworkState.online,
+        reason: 'ネットワーク監視起動後はオンライン状態になる必要がある',
+      );
+      expect(
+        container.read(networkProvider.notifier).isAIConversionAvailable,
+        isTrue,
+        reason: 'オンライン時はAI変換が利用可能になる必要がある',
+      );
+    });
+
+    testWidgets('F2: 接続状態変更ストリームの更新が状態へ反映される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: AppShell(
+              child: Scaffold(body: Text('test child')),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // リスナーが起動済みなので、オフラインイベントを流すと反映される
+      connectivityController.add([ConnectivityResult.none]);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(networkProvider),
+        NetworkState.offline,
+        reason: 'startListening起動後は接続変更が状態へ反映される必要がある',
+      );
+    });
+  });
+}

--- a/frontend/kotonoha_app/test/features/emergency/emergency_shell_wiring_test.dart
+++ b/frontend/kotonoha_app/test/features/emergency/emergency_shell_wiring_test.dart
@@ -67,8 +67,7 @@ void main() {
       );
     }
 
-    testWidgets('REQ-301: ホーム画面で緊急ボタンが表示される',
-        (WidgetTester tester) async {
+    testWidgets('REQ-301: ホーム画面で緊急ボタンが表示される', (WidgetTester tester) async {
       await tester.pumpWidget(buildTestApp());
       await tester.pumpAndSettle();
 

--- a/frontend/kotonoha_app/test/features/emergency/emergency_shell_wiring_test.dart
+++ b/frontend/kotonoha_app/test/features/emergency/emergency_shell_wiring_test.dart
@@ -1,0 +1,166 @@
+/// 緊急機能の全画面配線テスト（AppShell / ShellRoute経由）
+///
+/// F3: 緊急機能（緊急ボタン常時表示・緊急アラート表示）が
+/// AppShellを経由して全画面に配線されていることを検証する。
+///
+/// 関連要件:
+/// - REQ-301: 緊急ボタンの全画面常時表示
+/// - REQ-302: 2段階確認（ボタンタップ→確認ダイアログ→確認タップ）
+/// - REQ-304: 緊急アラート画面のフルスクリーン表示
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:kotonoha_app/core/router/app_router.dart';
+import 'package:kotonoha_app/features/emergency/presentation/providers/emergency_state_provider.dart';
+import 'package:kotonoha_app/features/emergency/presentation/screens/emergency_alert_screen.dart';
+import 'package:kotonoha_app/features/emergency/presentation/widgets/emergency_button_with_confirmation.dart';
+import 'package:kotonoha_app/features/settings/models/app_settings.dart';
+import 'package:kotonoha_app/features/settings/providers/settings_provider.dart';
+
+import '../../mocks/mock_emergency_audio_service.dart';
+
+void main() {
+  setUpAll(() {
+    // EmergencyStateNotifier.startEmergency/resetEmergency が呼び出す
+    // モックメソッドのデフォルト挙動を登録。
+    registerFallbackValue(Object());
+  });
+
+  group('緊急機能の全画面配線テスト（ShellRoute経由）', () {
+    late MockEmergencyAudioService mockAudioService;
+    late ProviderContainer container;
+    late GoRouter router;
+
+    setUp(() {
+      mockAudioService = MockEmergencyAudioService();
+      when(() => mockAudioService.startEmergencySound())
+          .thenAnswer((_) async {});
+      when(() => mockAudioService.stopEmergencySound())
+          .thenAnswer((_) async {});
+
+      container = ProviderContainer(
+        overrides: [
+          // 音声プラグイン依存を避けるためモックへ差し替え
+          emergencyAudioServiceProvider.overrideWithValue(mockAudioService),
+          // SettingsScreen等のローディング無限アニメーションを回避
+          settingsNotifierProvider.overrideWith(() => _MockSettingsNotifier()),
+        ],
+      );
+      router = container.read(routerProvider);
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    Widget buildTestApp() {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          routerConfig: router,
+        ),
+      );
+    }
+
+    testWidgets('REQ-301: ホーム画面で緊急ボタンが表示される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(EmergencyButtonWithConfirmation),
+        findsOneWidget,
+        reason: 'ホーム画面で緊急ボタンが常時表示される必要がある',
+      );
+      expect(
+        find.bySemanticsLabel('緊急呼び出しボタン'),
+        findsOneWidget,
+        reason: '緊急呼び出しボタンのSemanticsが存在する必要がある',
+      );
+    });
+
+    testWidgets('REQ-301: 別画面（/settings）でも緊急ボタンが表示される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pumpAndSettle();
+
+      router.go('/settings');
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(EmergencyButtonWithConfirmation),
+        findsOneWidget,
+        reason: '設定画面でも緊急ボタンが常時表示される必要がある（全画面常時表示）',
+      );
+    });
+
+    testWidgets('REQ-302/304: 緊急ボタン→確認→緊急アラート画面が表示され、リセットで戻る',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pumpAndSettle();
+
+      // 初期状態では緊急アラート画面は表示されない
+      expect(find.byType(EmergencyAlertScreen), findsNothing);
+
+      // 緊急ボタンをタップ → 確認ダイアログ表示（REQ-302 1段階目）
+      await tester.tap(find.byType(EmergencyButtonWithConfirmation));
+      await tester.pumpAndSettle();
+
+      // 確認ダイアログ（EmergencyConfirmationDialog）内の「はい」ボタンに限定。
+      // ホーム画面にも定型文等で「はい」テキストが存在しうるため、
+      // AlertDialog配下のElevatedButtonに絞り込む。
+      final confirmButton = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.widgetWithText(ElevatedButton, 'はい'),
+      );
+      expect(
+        confirmButton,
+        findsOneWidget,
+        reason: '緊急ボタンタップで確認ダイアログ（はいボタン）が表示される必要がある',
+      );
+
+      // 「はい」をタップ → 緊急処理開始（REQ-302 2段階目）
+      await tester.tap(confirmButton);
+      await tester.pumpAndSettle();
+
+      // 緊急アラート画面が最前面に表示される（REQ-304）
+      expect(
+        find.byType(EmergencyAlertScreen),
+        findsOneWidget,
+        reason: '確認後に緊急アラート画面がフルスクリーンで表示される必要がある',
+      );
+      expect(
+        find.text('緊急呼び出し中'),
+        findsOneWidget,
+        reason: '緊急アラート画面の「緊急呼び出し中」メッセージが表示される必要がある',
+      );
+      verify(() => mockAudioService.startEmergencySound()).called(1);
+
+      // リセットボタンで通常画面に戻る
+      await tester.tap(find.text('リセット'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(EmergencyAlertScreen),
+        findsNothing,
+        reason: 'リセット後は緊急アラート画面が消える必要がある',
+      );
+      verify(() => mockAudioService.stopEmergencySound()).called(1);
+    });
+  });
+}
+
+/// テスト用のモックSettingsNotifier
+///
+/// ローディング状態を回避するため、build()で即座にデフォルト設定を返す。
+class _MockSettingsNotifier extends SettingsNotifier {
+  @override
+  Future<AppSettings> build() async {
+    return const AppSettings();
+  }
+}


### PR DESCRIPTION
## 概要
コードレビュー(Critical)で判明した、**ネットワーク監視・緊急機能が実装済みなのに一切配線されていない**問題を修正します。

- **F2**: `NetworkNotifier.initializeWithConnectivity()` / `startListening()` がどこからも呼ばれず、状態が永久に `checking` のまま → `isAIConversionAvailable` が常に false で **AI変換が常時無効**でした。
- **F3**: 緊急機能（ボタン/状態Provider/アラート画面/`startEmergency()`）が emergency/ 配下以外から参照ゼロ → **全画面常時表示(REQ-301)も赤画面アラート(REQ-304)も発火しない**安全機能の不全状態でした。

## 設計：ShellRoute による全画面共通シェル
新設 `lib/core/widgets/app_shell.dart`（`AppShell`）を go_router の `ShellRoute` から全6ルートに適用し、横断的関心事を一箇所に集約します。

- **F2（ネットワーク起動）**: `AppShell.initState` の post-frame callback で一度だけ `initializeWithConnectivity()` → `startListening()`。テスト環境のプラグイン未モックでも落ちないよう try/catch。
- **F3（緊急機能）**: `Stack` で現在画面の上に
  - 右下に `EmergencyButtonWithConfirmation` を常時表示（REQ-301/302）。
  - `emergencyStateProvider == alertActive` のとき `EmergencyAlertScreen` を `Positioned.fill` で最前面表示（REQ-304）、リセットで復帰。
- ShellRoute の child は Shell 配下の Navigator に属するため、緊急ボタンの確認ダイアログ（`Navigator.of(context)`）が正しく動作します。

## 変更内容
- 新規 `lib/core/widgets/app_shell.dart`。
- `lib/core/router/app_router.dart`：6つの `GoRoute` を単一 `ShellRoute` で内包（path/name/initialLocation/errorBuilder は不変）。
- `test/core/router/app_router_test.dart`：ShellRoute 構成に追随（「6画面・名前付き・home 初期」の検証意図は維持）。
- 追加テスト：`app_shell_network_test.dart`（監視起動）, `emergency_shell_wiring_test.dart`（全画面ボタン表示・確認→赤画面→リセット）。

## テスト
- `flutter test`: **All tests passed!（1446件）**、`flutter analyze` 変更ファイル指摘ゼロ。
- `pubspec.lock` は不変。

## 注意 ⚠️
- `assets/audio/emergency_alarm.mp3` は **0バイトのプレースホルダ**です。実運用には緊急音の実音声ファイルが必要です（音声再生に失敗しても赤画面アラートは継続表示される設計）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)