### PR TITLE
[codex] Fix AI conversion review findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ PROJECT_NAME=kotonoha API
 VERSION=1.0.0
 ACCESS_TOKEN_EXPIRE_MINUTES=11520
 
+# 端末APIキー認証（AI変換APIの保護用）
+# バックエンドはAPI_KEYSに含まれる値をX-API-Keyとして受け付けます。
+# Flutterビルド時は同じ値をAI_API_KEYへ渡してください。
+API_KEYS=
+
+# Flutterビルド設定
+API_BASE_URL=http://localhost:8000
+AI_API_KEY=
+
 # AI API設定（OpenAI）
 # OPENAI_API_KEY=sk-your-openai-api-key-here
 # OPENAI_MODEL=gpt-4o-mini

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -15,6 +15,8 @@ on:
 env:
   FLUTTER_VERSION: '3.38.1'
   JAVA_VERSION: '17'
+  API_BASE_URL: ${{ vars.API_BASE_URL || 'http://localhost:8000' }}
+  AI_API_KEY: ${{ secrets.AI_API_KEY || '' }}
 
 jobs:
   analyze:
@@ -174,7 +176,10 @@ jobs:
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
       - name: Build Web (Release)
-        run: flutter build web --release
+        run: >
+          flutter build web --release
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Upload Web build
         uses: actions/upload-artifact@v6
@@ -215,7 +220,10 @@ jobs:
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
       - name: Build APK (Release)
-        run: flutter build apk --release --flavor internal
+        run: >
+          flutter build apk --release --flavor internal
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Upload APK
         uses: actions/upload-artifact@v6
@@ -251,7 +259,10 @@ jobs:
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
       - name: Build iOS (no codesign)
-        run: flutter build ios --release --no-codesign
+        run: >
+          flutter build ios --release --no-codesign
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Upload iOS build
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 env:
   FLUTTER_VERSION: '3.38.1'
   JAVA_VERSION: '17'
+  API_BASE_URL: ${{ vars.API_BASE_URL || 'http://localhost:8000' }}
+  AI_API_KEY: ${{ secrets.AI_API_KEY || '' }}
 
 jobs:
   validate-tag:
@@ -52,7 +54,10 @@ jobs:
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
       - name: Build Web (Release)
-        run: flutter build web --release --web-renderer html
+        run: >
+          flutter build web --release --web-renderer html
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Create Web archive
         run: |
@@ -121,10 +126,16 @@ jobs:
           EOF
 
       - name: Build APK (Release)
-        run: flutter build apk --release
+        run: >
+          flutter build apk --release
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Build App Bundle (Release)
-        run: flutter build appbundle --release
+        run: >
+          flutter build appbundle --release
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Rename artifacts
         run: |
@@ -189,7 +200,10 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
 
       - name: Build iOS (no codesign for testing)
-        run: flutter build ios --release --no-codesign
+        run: >
+          flutter build ios --release --no-codesign
+          --dart-define=API_BASE_URL="${API_BASE_URL}"
+          --dart-define=AI_API_KEY="${AI_API_KEY}"
 
       - name: Create IPA archive
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,233 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+**kotonoha（ことのは）** - 文字盤コミュニケーション支援アプリ
+
+発話困難な方が「できるだけ少ない操作で、自分の言いたいことを、適切な丁寧さで、安全に伝えられる」ことを目的としたタブレット向けコミュニケーション支援アプリケーション。
+
+対象ユーザー: 脳梗塞・ALS・筋疾患などで発話が困難だが、タブレットのタップ操作がある程度可能な方々
+
+## 開発フレームワーク: Tsumiki
+
+このプロジェクトは **Tsumiki** (https://github.com/classmethod/tsumiki) を使用して開発されています。
+
+### Tsumikiとは
+
+Tsumikiは、要件定義から設計、タスク管理、テスト駆動実装まで一貫したワークフローを提供するCodexプラグインです。EARS記法による構造化要件定義、自動ドキュメント生成、依存関係を考慮したタスク管理を特徴とします。
+
+### 主要なTsumikiコマンド
+
+**Kairo（包括フロー）** - メイン開発フロー:
+- `/tsumiki:init-tech-stack` - 技術スタック選定
+- `/tsumiki:kairo-requirements` - EARS記法による要件定義書作成
+- `/tsumiki:kairo-design` - 技術設計文書生成
+- `/tsumiki:kairo-tasks` - 実装タスク分割（1日単位、1ヶ月フェーズ）
+- `/tsumiki:kairo-implement` - タスク実装
+
+**TDD開発サイクル**:
+- `/tsumiki:tdd-requirements` - 機能要件整理
+- `/tsumiki:tdd-testcases` - テストケース洗い出し
+- `/tsumiki:tdd-red` - 失敗するテスト作成
+- `/tsumiki:tdd-green` - テストを通す実装
+- `/tsumiki:tdd-refactor` - リファクタリング
+- `/tsumiki:tdd-verify-complete` - 完了検証
+
+**リバースエンジニアリング**（既存コード分析用）:
+- `/tsumiki:rev-tasks` - 実装済み機能からタスク抽出
+- `/tsumiki:rev-design` - アーキテクチャ設計書逆生成
+- `/tsumiki:rev-specs` - テストケース・仕様書逆生成
+- `/tsumiki:rev-requirements` - 要件定義書逆生成
+
+## 技術スタック
+
+- **フロントエンド**: Flutter 3.38.1 + Riverpod 2.x
+- **バックエンド**: FastAPI 0.121 + SQLAlchemy 2.x + PostgreSQL 15+
+- **IaC**: AWS CDK 2.x (TypeScript)
+- **開発環境**: Docker + Docker Compose
+
+詳細な技術スタック、セットアップ手順、推奨ディレクトリ構造については `docs/tech-stack.md` を参照してください。
+
+## アーキテクチャの重要な設計判断
+
+### オフラインファースト設計 🔵
+- **基本機能はすべてオフラインで動作** (文字盤入力、定型文、履歴、TTS読み上げ)
+- AI変換のみオンライン必須、オフライン時は無効化
+- ユーザーデータは**端末内ローカル保存**（Hive使用）
+- プライバシー重視: クラウド同期なし、単一端末完結
+
+### パフォーマンス要件
+- TTS読み上げ開始: **1秒以内** (OS標準TTS利用でローカル処理)
+- 文字盤タップ応答: **100ms以内**
+- AI変換応答: **平均3秒以内**
+
+### アクセシビリティ要件
+- タップターゲットサイズ: **最小44px × 44px、推奨60px × 60px**
+- フォントサイズ: 小/中/大の3段階
+- テーマ: ライト/ダーク/高コントラストの3種類
+- 高コントラストモード: WCAG 2.1 AAレベル（コントラスト比4.5:1以上）
+- タップ主体の操作（スワイプ等のジェスチャーに依存しない）
+
+## ディレクトリ構造
+
+### Tsumiki生成ドキュメント（docs/）
+
+```
+docs/
+├── tech-stack.md              # 技術スタック定義・セットアップ手順
+├── spec/                      # 要件定義（EARS記法）
+│   ├── kotonoha-requirements.md
+│   ├── kotonoha-user-stories.md
+│   └── kotonoha-acceptance-criteria.md
+├── design/kotonoha/           # 技術設計
+│   ├── architecture.md
+│   ├── dataflow.md
+│   ├── api-endpoints.md
+│   ├── database-schema.sql
+│   └── interfaces.dart
+└── tasks/                     # タスク管理（フェーズ分割）
+    ├── kotonoha-overview.md
+    ├── kotonoha-phase1.md ... phase5.md
+```
+
+backend/、frontend/、docker/などのコード構造については `docs/tech-stack.md` を参照してください。
+
+## 開発コマンド
+
+よく使うコマンド：
+
+```bash
+# Docker環境起動
+docker-compose up -d
+
+# バックエンドサーバー起動
+cd backend
+uvicorn app.main:app --reload
+
+# Flutterアプリ起動
+cd frontend/kotonoha_app
+flutter run -d chrome
+
+# テスト実行
+pytest                    # Backend
+flutter test              # Frontend
+
+# コード生成（Riverpod, Hive等）
+flutter pub run build_runner build --delete-conflicting-outputs
+
+# DBマイグレーション
+alembic upgrade head
+```
+
+詳細なコマンド、セットアップ手順については `docs/tech-stack.md` を参照してください。
+
+## テスト戦略
+
+### 品質基準
+- 全体カバレッジ: **80%以上**
+- ビジネスロジック・APIエンドポイント: **90%以上**
+- コード品質: flutter_lints、Ruff + Black準拠
+
+### TDD開発フロー（Tsumiki推奨）
+1. `/tsumiki:tdd-requirements` - 機能要件を整理
+2. `/tsumiki:tdd-testcases` - テストケースを洗い出し
+3. `/tsumiki:tdd-red` - 失敗するテストを作成
+4. `/tsumiki:tdd-green` - テストを通す最小限の実装
+5. `/tsumiki:tdd-refactor` - リファクタリング
+6. `/tsumiki:tdd-verify-complete` - 全テスト成功を検証
+
+## API仕様
+
+### ベースURL
+- 開発環境: `http://localhost:8000`
+- ドキュメント: `http://localhost:8000/docs` (Swagger UI)
+
+### 主要エンドポイント
+- `POST /api/v1/ai/convert` - AI変換（平均3秒以内）
+  - 入力テキストを丁寧さレベルに応じて変換
+  - politeness_level: "casual", "normal", "polite"
+- `POST /api/v1/ai/regenerate` - AI変換再生成
+- `GET /api/v1/health` - ヘルスチェック
+
+### レート制限
+- AI変換API: 1分間に10リクエスト
+
+## セキュリティ・プライバシー
+
+### データ保存ポリシー
+- **ローカルストレージ優先**: 定型文、履歴、お気に入り、設定はすべて端末内（Hive）
+- **AI変換時のプライバシー**: 初回利用時に明示的な同意取得、プライバシーポリシー表示
+- **通信セキュリティ**: HTTPS/TLS 1.2+、JWT認証
+- **データ削除**: ユーザーが任意に削除可能、アンインストール時全削除
+
+### 環境変数管理
+- 開発: `.env`ファイル（Gitignore必須）
+- 本番: クラウド環境変数機能（AWS Secrets Manager等）
+- `.env.example`を参照してセットアップ
+
+## 重要な制約・前提条件
+
+### MVP範囲外（実装しない）
+- クラウド同期・アカウント管理・複数端末間のデータ共有
+- 視線入力・外部スイッチ・スキャン入力などの特殊インターフェース
+- 音声認識（音声入力）機能
+- 画像・絵文字・スタンプ機能
+- ビデオ通話連携
+
+### プラットフォーム要件
+- iOS: 14.0以上、Android: 10以上、Web: Chrome/Safari/Edge最新版
+- 推奨デバイス: 9.7インチ以上のタブレット
+
+詳細は `docs/design/kotonoha/architecture.md` を参照してください。
+
+## 開発ワークフロー（Tsumiki推奨）
+
+### 新機能開発の流れ
+1. `/tsumiki:kairo-requirements` - 要件定義（EARS記法）
+2. `/tsumiki:kairo-design` - 設計書生成
+3. `/tsumiki:kairo-tasks` - タスク分割（1日単位）
+4. `/tsumiki:kairo-implement` - TDDサイクルで実装
+5. CI/CD自動テスト・デプロイ
+
+### コミット戦略
+- **1タスク完了ごとにコミット**: タスク（TASK-XXXX）が完了したら、必ずその時点でGitコミットを作成すること
+- コミットメッセージ形式: `タスク内容 (TASK-XXXX)`
+- 例: `Add Docker environment setup (TASK-0002)`
+- 変更履歴を細かく記録し、問題発生時のロールバックを容易にする
+
+Git ブランチ戦略等の詳細は `docs/tech-stack.md` を参照してください。
+
+## 参考資料
+
+### プロジェクト内ドキュメント
+- **技術スタック・セットアップ**: `docs/tech-stack.md`
+- **要件定義書**: `docs/spec/kotonoha-requirements.md`
+- **アーキテクチャ設計**: `docs/design/kotonoha/architecture.md`
+- **データフロー図**: `docs/design/kotonoha/dataflow.md`
+- **API仕様**: `docs/design/kotonoha/api-endpoints.md`
+- **タスク管理**: `docs/tasks/kotonoha-overview.md`
+- **Tsumiki Manual**: https://github.com/classmethod/tsumiki/blob/main/MANUAL.md
+
+## 注意事項
+
+### Tsumiki生成コンテンツについて
+- Tsumikiが生成したドキュメント（docs/配下）は**人間のレビューが必須**
+- 特に非機能要件やエッジケースは推定を含むため、実装時に検証が必要
+- 🔵（青信号）は要件定義書ベース、🟡（黄信号）は妥当な推測、🔴（赤信号）は完全な推測
+
+### コーディング規約
+- **Flutter**:
+  - Null Safety有効
+  - `const`コンストラクタを可能な限り使用
+  - ウィジェットは`key`パラメータを持つ
+- **Python**:
+  - 型ヒント必須
+  - 行長100文字以内
+  - docstringはGoogle Styleで記述
+
+### パフォーマンス最適化
+- TTS読み上げはOS標準を使用（低遅延）
+- 文字盤UIはネイティブFlutterウィジェット（100ms応答）
+- AI変換は非同期処理、3秒超過時はローディング表示

--- a/README.md
+++ b/README.md
@@ -222,8 +222,14 @@ flutter test --coverage          # カバレッジ測定
 | `POSTGRES_HOST` | データベースホスト | localhost |
 | `POSTGRES_PORT` | データベースポート | 5432 |
 | `SECRET_KEY` | JWT認証用シークレットキー | - |
+| `API_KEYS` | AI変換APIで許可する端末APIキー（カンマ区切り） | 空 |
+| `API_BASE_URL` | Flutterビルド時に埋め込むバックエンドURL | http://localhost:8000 |
+| `AI_API_KEY` | Flutterビルド時に埋め込む端末APIキー。`API_KEYS` のいずれかを指定 | 空 |
 | `OPENAI_API_KEY` | OpenAI APIキー（オプション） | - |
 | `ENVIRONMENT` | 環境設定 | development |
+
+`AI_API_KEY` はクライアントアプリに埋め込まれるため、強い秘密情報としては扱えません。
+匿名利用による過剰リクエストを抑える端末キーとして、リリースごとにローテーションできる値を指定してください。
 
 ## CI/CD
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,11 @@ ACCESS_TOKEN_EXPIRE_MINUTES=11520  # 8日間 (60 * 24 * 8)
 # 例: API_KEYS=device-key-aaaa,device-key-bbbb
 API_KEYS=
 
+# Flutterビルド時に使用する値
+# API_BASE_URLはデプロイ先バックエンドURL、AI_API_KEYは上記API_KEYSのいずれかを指定してください。
+API_BASE_URL=http://localhost:8000
+AI_API_KEY=
+
 # -----------------------------------------------------------------------------
 # セッション設定
 # -----------------------------------------------------------------------------

--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -37,12 +37,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# レート制限ヘッダー定数（設定駆動）
-RATE_LIMIT_HEADERS = {
-    "X-RateLimit-Limit": str(settings.RATE_LIMIT_TIMES),
-    "X-RateLimit-Remaining": "0",
-    "X-RateLimit-Reset": str(settings.RATE_LIMIT_SECONDS),
-}
+
+def _rate_limit_headers(remaining: int | None = None) -> dict[str, str]:
+    """設定値に基づくレート制限ヘッダーを生成する。"""
+    remaining_count = (
+        max(settings.RATE_LIMIT_TIMES - 1, 0) if remaining is None else max(remaining, 0)
+    )
+    return {
+        "X-RateLimit-Limit": str(settings.RATE_LIMIT_TIMES),
+        "X-RateLimit-Remaining": str(remaining_count),
+        "X-RateLimit-Reset": str(settings.RATE_LIMIT_SECONDS),
+    }
 
 
 @dataclass(frozen=True)
@@ -110,7 +115,7 @@ def _create_error_response(error_info: ErrorInfo) -> JSONResponse:
                 "status_code": error_info.status_code,
             },
         },
-        headers=RATE_LIMIT_HEADERS,
+        headers=_rate_limit_headers(remaining=0 if error_info.status_code == 429 else None),
     )
 
 
@@ -224,7 +229,7 @@ async def convert_text(
 
         return JSONResponse(
             content=response_data,
-            headers=RATE_LIMIT_HEADERS,
+            headers=_rate_limit_headers(),
         )
 
     except (
@@ -312,7 +317,7 @@ async def regenerate_text(
 
         return JSONResponse(
             content=response_data,
-            headers=RATE_LIMIT_HEADERS,
+            headers=_rate_limit_headers(),
         )
 
     except (

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,21 +4,25 @@
 環境変数から設定を読み込み、型安全に管理する。
 """
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEV_SECRET_KEY = "dev-secret-key-change-me"  # noqa: S105
+DEV_POSTGRES_PASSWORD = "your_secure_password_here"  # noqa: S105
 
 
 class Settings(BaseSettings):
     """アプリケーション設定クラス"""
 
     # データベース設定
-    POSTGRES_USER: str
-    POSTGRES_PASSWORD: str
+    POSTGRES_USER: str = "kotonoha_user"
+    POSTGRES_PASSWORD: str = DEV_POSTGRES_PASSWORD
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: int = 5432
-    POSTGRES_DB: str
+    POSTGRES_DB: str = "kotonoha_db"
 
     # API設定
-    SECRET_KEY: str
+    SECRET_KEY: str = DEV_SECRET_KEY
     API_HOST: str = "0.0.0.0"  # noqa: S104
     API_PORT: int = 8000
     API_V1_STR: str = "/api/v1"
@@ -100,6 +104,19 @@ class Settings(BaseSettings):
     def API_KEYS_LIST(self) -> list[str]:  # noqa: N802
         """有効な端末APIキーのリスト（空要素は除外）"""
         return [key.strip() for key in self.API_KEYS.split(",") if key.strip()]
+
+    @model_validator(mode="after")
+    def validate_production_settings(self) -> "Settings":
+        """本番環境では開発用の弱い既定値を拒否する。"""
+        if self.ENVIRONMENT != "production":
+            return self
+
+        if self.SECRET_KEY == DEV_SECRET_KEY:
+            raise ValueError("SECRET_KEY must be set explicitly in production")
+        if self.POSTGRES_PASSWORD == DEV_POSTGRES_PASSWORD:
+            raise ValueError("POSTGRES_PASSWORD must be set explicitly in production")
+
+        return self
 
 
 # グローバル設定インスタンス

--- a/backend/app/models/ai_conversion_history.py
+++ b/backend/app/models/ai_conversion_history.py
@@ -147,8 +147,8 @@ class AIConversionHistory(Base):
     def __repr__(self) -> str:
         """
         【機能概要】: モデルインスタンスの文字列表現を返す
-        【実装方針】: デバッグ用にidとinput_textを含む文字列を返す
+        【実装方針】: デバッグ用にidのみを含む文字列を返す
         🟡 デバッグ用の補助機能（要件定義書には明記されていないが、開発時に有用）
         """
-        # 【文字列表現】: モデルの主要情報を含む文字列を生成
-        return f"<AIConversionHistory(id={self.id}, input_text='{self.input_text[:20]}...')>"
+        # 【文字列表現】: 平文の入力内容をログ等へ漏らさない
+        return f"<AIConversionHistory(id={self.id})>"

--- a/backend/app/utils/ai_client.py
+++ b/backend/app/utils/ai_client.py
@@ -171,7 +171,7 @@ class AIClient:
 
             logger.info(
                 f"Claude conversion completed in {conversion_time_ms}ms: "
-                f"'{input_text[:20]}...' -> '{converted_text[:20]}...'"
+                f"input_length={len(input_text)}, output_length={len(converted_text)}"
             )
 
             return converted_text, conversion_time_ms
@@ -251,7 +251,7 @@ class AIClient:
 
             logger.info(
                 f"OpenAI conversion completed in {conversion_time_ms}ms: "
-                f"'{input_text[:20]}...' -> '{converted_text[:20]}...'"
+                f"input_length={len(input_text)}, output_length={len(converted_text)}"
             )
 
             return converted_text, conversion_time_ms
@@ -393,7 +393,7 @@ class AIClient:
 
             logger.info(
                 f"AI regeneration completed in {conversion_time_ms}ms: "
-                f"'{input_text[:20]}...' -> '{converted_text[:20]}...'"
+                f"input_length={len(input_text)}, output_length={len(converted_text)}"
             )
 
             return converted_text, conversion_time_ms

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,15 @@ services:
       dockerfile: ./docker/backend/Dockerfile
     container_name: kotonoha_backend
     environment:
+      POSTGRES_USER: ${POSTGRES_USER:-kotonoha_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-your_secure_password}
+      POSTGRES_DB: ${POSTGRES_DB:-kotonoha_db}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-kotonoha_user}:${POSTGRES_PASSWORD:-your_secure_password}@postgres:5432/${POSTGRES_DB:-kotonoha_db}
       TEST_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-kotonoha_user}:${POSTGRES_PASSWORD:-your_secure_password}@postgres:5432/kotonoha_test
       SECRET_KEY: ${SECRET_KEY:-your-secret-key-change-in-production}
+      API_KEYS: ${API_KEYS:-}
     ports:
       - "8000:8000"
     volumes:

--- a/frontend/kotonoha_app/lib/features/ai_conversion/data/api/ai_conversion_api_client.dart
+++ b/frontend/kotonoha_app/lib/features/ai_conversion/data/api/ai_conversion_api_client.dart
@@ -24,14 +24,17 @@ class AIConversionApiClient {
   /// コンストラクタ
   ///
   /// [baseUrl] APIのベースURL（例: http://localhost:8000）
-  AIConversionApiClient({required String baseUrl})
-      : dio = Dio(BaseOptions(
+  AIConversionApiClient({
+    required String baseUrl,
+    String apiKey = '',
+  }) : dio = Dio(BaseOptions(
           baseUrl: baseUrl,
           connectTimeout: const Duration(seconds: 10),
           receiveTimeout: const Duration(seconds: 10),
           headers: {
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            if (apiKey.isNotEmpty) 'X-API-Key': apiKey,
           },
         ));
 
@@ -152,13 +155,25 @@ class AIConversionApiClient {
     String? errorCode;
     String? errorMessage;
     if (data is Map<String, dynamic> && data.containsKey('error')) {
-      final error = data['error'] as Map<String, dynamic>?;
-      errorCode = error?['code'] as String?;
-      errorMessage = error?['message'] as String?;
+      final error = data['error'];
+      if (error is Map<String, dynamic>) {
+        errorCode = error['code'] as String?;
+        errorMessage = error['message'] as String?;
+      } else if (error is String) {
+        errorMessage = error;
+        errorCode = data['error_code'] as String?;
+      }
     }
 
     switch (statusCode) {
+      case 401:
+        return AIConversionException(
+          code: errorCode ?? 'AUTHENTICATION_ERROR',
+          message: errorMessage ?? 'AI変換APIの認証設定を確認してください。',
+        );
+
       case 400:
+      case 422:
         return AIConversionException(
           code: errorCode ?? 'VALIDATION_ERROR',
           message: errorMessage ?? '入力内容を確認してください。',
@@ -173,6 +188,7 @@ class AIConversionApiClient {
       case 500:
       case 502:
       case 503:
+      case 504:
         return AIConversionException(
           code: errorCode ?? 'AI_API_ERROR',
           message: errorMessage ?? 'AI変換APIでエラーが発生しました。しばらく時間をおいて再試行してください。',

--- a/frontend/kotonoha_app/lib/features/ai_conversion/presentation/widgets/ai_conversion_button.dart
+++ b/frontend/kotonoha_app/lib/features/ai_conversion/presentation/widgets/ai_conversion_button.dart
@@ -63,6 +63,7 @@ class AIConversionButton extends ConsumerStatefulWidget {
   /// - [onConvert]: 変換処理のコールバック
   /// - [onConversionStart]: 変換開始時の通知（オプション）
   /// - [onConversionComplete]: 変換完了時の通知（オプション）
+  /// - [onConversionError]: 変換失敗時の通知（オプション）
   /// 🔵 信頼性レベル: 青信号
   const AIConversionButton({
     super.key,
@@ -71,6 +72,7 @@ class AIConversionButton extends ConsumerStatefulWidget {
     required this.onConvert,
     this.onConversionStart,
     this.onConversionComplete,
+    this.onConversionError,
   });
 
   /// 【プロパティ定義】: 変換対象の入力テキスト
@@ -97,6 +99,10 @@ class AIConversionButton extends ConsumerStatefulWidget {
   /// 【用途】: 変換結果の親ウィジェットへの伝達
   /// 🟡 信頼性レベル: 黄信号 - UI連携のため
   final void Function(String result)? onConversionComplete;
+
+  /// 【プロパティ定義】: 変換失敗時のコールバック（オプション）
+  /// 【用途】: 親ウィジェットでエラー表示を行う
+  final void Function(Object error)? onConversionError;
 
   @override
   ConsumerState<AIConversionButton> createState() => _AIConversionButtonState();
@@ -165,6 +171,8 @@ class _AIConversionButtonState extends ConsumerState<AIConversionButton> {
 
       // 【コールバック呼び出し】: 変換完了を通知
       widget.onConversionComplete?.call(result);
+    } catch (e) {
+      widget.onConversionError?.call(e);
     } finally {
       // 【状態更新】: ローディング終了（マウント状態を確認）
       // 【安全性確保】: アンマウント後のsetState呼び出しを防止

--- a/frontend/kotonoha_app/lib/features/ai_conversion/providers/ai_conversion_provider.dart
+++ b/frontend/kotonoha_app/lib/features/ai_conversion/providers/ai_conversion_provider.dart
@@ -22,7 +22,8 @@ final aiConversionApiClientProvider = Provider<AIConversionApiClient>((ref) {
     'API_BASE_URL',
     defaultValue: 'http://localhost:8000',
   );
-  return AIConversionApiClient(baseUrl: baseUrl);
+  const apiKey = String.fromEnvironment('AI_API_KEY');
+  return AIConversionApiClient(baseUrl: baseUrl, apiKey: apiKey);
 });
 
 /// AI変換Providerの定義

--- a/frontend/kotonoha_app/lib/features/character_board/presentation/home_screen.dart
+++ b/frontend/kotonoha_app/lib/features/character_board/presentation/home_screen.dart
@@ -10,6 +10,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kotonoha_app/core/constants/app_sizes.dart';
 import 'package:kotonoha_app/core/router/app_router.dart';
+import 'package:kotonoha_app/features/ai_conversion/domain/exceptions/ai_conversion_exception.dart';
+import 'package:kotonoha_app/features/ai_conversion/domain/models/politeness_level.dart';
+import 'package:kotonoha_app/features/ai_conversion/presentation/widgets/ai_conversion_button.dart';
+import 'package:kotonoha_app/features/ai_conversion/presentation/widgets/ai_conversion_result_dialog.dart';
+import 'package:kotonoha_app/features/ai_conversion/presentation/widgets/politeness_level_selector.dart';
+import 'package:kotonoha_app/features/ai_conversion/providers/ai_conversion_provider.dart';
 import 'package:kotonoha_app/features/character_board/presentation/widgets/character_board_widget.dart';
 import 'package:kotonoha_app/features/character_board/presentation/widgets/delete_button.dart';
 import 'package:kotonoha_app/features/character_board/presentation/widgets/clear_all_button.dart';
@@ -41,7 +47,9 @@ class HomeScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final inputBuffer = ref.watch(inputBufferProvider);
     final settingsAsync = ref.watch(settingsNotifierProvider);
-    final fontSize = settingsAsync.asData?.value.fontSize ?? FontSize.medium;
+    final settings = settingsAsync.asData?.value;
+    final fontSize = settings?.fontSize ?? FontSize.medium;
+    final aiPoliteness = settings?.aiPoliteness ?? PolitenessLevel.normal;
 
     return Scaffold(
       appBar: AppBar(
@@ -154,6 +162,52 @@ class HomeScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: AppSizes.paddingSmall),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.paddingMedium,
+              ),
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: AppSizes.paddingMedium,
+                runSpacing: AppSizes.paddingSmall,
+                children: [
+                  PolitenessLevelSelector(
+                    selectedLevel: aiPoliteness,
+                    onLevelChanged: (level) {
+                      ref
+                          .read(settingsNotifierProvider.notifier)
+                          .setAIPoliteness(level);
+                    },
+                  ),
+                  AIConversionButton(
+                    inputText: inputBuffer,
+                    politenessLevel: aiPoliteness,
+                    onConvert: () => _convertWithAI(
+                      context,
+                      ref,
+                      inputBuffer,
+                      aiPoliteness,
+                    ),
+                    onConversionComplete: (convertedText) {
+                      if (!context.mounted) return;
+                      _showConversionResult(
+                        context,
+                        ref,
+                        inputBuffer,
+                        convertedText,
+                        aiPoliteness,
+                      );
+                    },
+                    onConversionError: (error) {
+                      if (!context.mounted) return;
+                      _showAIConversionError(context, error);
+                    },
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSizes.paddingSmall),
             // 文字盤
             Expanded(
               child: Padding(
@@ -187,6 +241,136 @@ class HomeScreen extends ConsumerWidget {
     ref
         .read(historyProvider.notifier)
         .addHistory(text, HistoryType.manualInput);
+  }
+
+  Future<String> _convertWithAI(
+    BuildContext context,
+    WidgetRef ref,
+    String inputText,
+    PolitenessLevel politenessLevel,
+  ) async {
+    final hasConsent = await _ensureAIPrivacyConsent(context, ref);
+    if (!hasConsent) {
+      throw const AIConversionException(
+        code: 'PRIVACY_CONSENT_REQUIRED',
+        message: 'AI変換を利用するにはプライバシー同意が必要です。',
+      );
+    }
+
+    await ref.read(aiConversionProvider.notifier).convert(
+          inputText: inputText,
+          politenessLevel: politenessLevel,
+        );
+
+    final state = ref.read(aiConversionProvider);
+    if (state.hasResult && state.convertedText != null) {
+      return state.convertedText!;
+    }
+
+    throw state.error ??
+        const AIConversionException(
+          code: 'AI_CONVERSION_FAILED',
+          message: 'AI変換に失敗しました。しばらく待ってから再度お試しください。',
+        );
+  }
+
+  Future<bool> _ensureAIPrivacyConsent(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final loadedSettings = ref.read(settingsNotifierProvider).asData?.value;
+    final settings =
+        loadedSettings ?? await ref.read(settingsNotifierProvider.future);
+    if (settings == null) return false;
+    if (settings.hasAcceptedAIPrivacyPolicy) return true;
+    if (!context.mounted) return false;
+
+    final accepted = await showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (dialogContext) => AlertDialog(
+            title: const Text('AI変換の利用確認'),
+            content: const Text(
+              'AI変換では入力した文章を外部のAIサービスへ送信します。送信前に内容を確認し、同意できる場合のみ利用してください。',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: const Text('同意しない'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                child: const Text('同意して利用'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+
+    if (accepted) {
+      await ref
+          .read(settingsNotifierProvider.notifier)
+          .setAIPrivacyConsent(true);
+    }
+    return accepted;
+  }
+
+  void _showConversionResult(
+    BuildContext context,
+    WidgetRef ref,
+    String originalText,
+    String convertedText,
+    PolitenessLevel politenessLevel,
+  ) {
+    AIConversionResultDialog.show(
+      context: context,
+      originalText: originalText,
+      convertedText: convertedText,
+      politenessLevel: politenessLevel,
+      onAdopt: (result) {
+        Navigator.of(context).pop();
+        ref.read(inputBufferProvider.notifier).setText(result);
+      },
+      onRegenerate: () {
+        Navigator.of(context).pop();
+        Future<void>.microtask(() async {
+          if (!context.mounted) return;
+          try {
+            final result = await _convertWithAI(
+              context,
+              ref,
+              originalText,
+              politenessLevel,
+            );
+            if (!context.mounted) return;
+            _showConversionResult(
+              context,
+              ref,
+              originalText,
+              result,
+              politenessLevel,
+            );
+          } catch (e) {
+            if (context.mounted) {
+              _showAIConversionError(context, e);
+            }
+          }
+        });
+      },
+      onUseOriginal: (original) {
+        Navigator.of(context).pop();
+        ref.read(inputBufferProvider.notifier).setText(original);
+      },
+    );
+  }
+
+  void _showAIConversionError(BuildContext context, Object error) {
+    final message = error is AIConversionException
+        ? error.message
+        : 'AI変換に失敗しました。しばらく待ってから再度お試しください。';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   /// FontSizeからフォントサイズ値を取得

--- a/frontend/kotonoha_app/lib/features/character_board/presentation/home_screen.dart
+++ b/frontend/kotonoha_app/lib/features/character_board/presentation/home_screen.dart
@@ -274,6 +274,32 @@ class HomeScreen extends ConsumerWidget {
         );
   }
 
+  Future<String> _regenerateWithAI(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final hasConsent = await _ensureAIPrivacyConsent(context, ref);
+    if (!hasConsent) {
+      throw const AIConversionException(
+        code: 'PRIVACY_CONSENT_REQUIRED',
+        message: 'AI変換を利用するにはプライバシー同意が必要です。',
+      );
+    }
+
+    await ref.read(aiConversionProvider.notifier).regenerate();
+
+    final state = ref.read(aiConversionProvider);
+    if (state.hasResult && state.convertedText != null) {
+      return state.convertedText!;
+    }
+
+    throw state.error ??
+        const AIConversionException(
+          code: 'AI_REGENERATION_FAILED',
+          message: 'AI再生成に失敗しました。しばらく待ってから再度お試しください。',
+        );
+  }
+
   Future<bool> _ensureAIPrivacyConsent(
     BuildContext context,
     WidgetRef ref,
@@ -336,12 +362,7 @@ class HomeScreen extends ConsumerWidget {
         Future<void>.microtask(() async {
           if (!context.mounted) return;
           try {
-            final result = await _convertWithAI(
-              context,
-              ref,
-              originalText,
-              politenessLevel,
-            );
+            final result = await _regenerateWithAI(context, ref);
             if (!context.mounted) return;
             _showConversionResult(
               context,
@@ -365,6 +386,11 @@ class HomeScreen extends ConsumerWidget {
   }
 
   void _showAIConversionError(BuildContext context, Object error) {
+    if (error is AIConversionException &&
+        error.code == 'PRIVACY_CONSENT_REQUIRED') {
+      return;
+    }
+
     final message = error is AIConversionException
         ? error.message
         : 'AI変換に失敗しました。しばらく待ってから再度お試しください。';

--- a/frontend/kotonoha_app/lib/features/settings/models/app_settings.dart
+++ b/frontend/kotonoha_app/lib/features/settings/models/app_settings.dart
@@ -10,7 +10,7 @@ import '../../tts/domain/models/tts_speed.dart';
 import '../../ai_conversion/domain/models/politeness_level.dart';
 
 // 【実装内容】: アプリ設定を保持する不変オブジェクト
-// 【REQ-801, REQ-803, REQ-404, REQ-903対応】: フォントサイズ、テーマ、TTS速度、AI丁寧さレベルの設定を管理
+// 【REQ-801, REQ-803, REQ-404, REQ-903対応】: フォントサイズ、テーマ、TTS速度、AI丁寧さレベル、AI利用同意を管理
 class AppSettings {
   // 【フォントサイズ設定】: 3段階（小・中・大）
   // 🔵 青信号: REQ-801のフォントサイズ要件に基づく
@@ -28,7 +28,11 @@ class AppSettings {
   // 🔵 青信号: REQ-903のAI変換丁寧さレベル要件に基づく
   final PolitenessLevel aiPoliteness;
 
-  // 【コンストラクタ】: デフォルト値を設定（medium、light、normal、normal）
+  // 【AIプライバシー同意】: AI変換で外部APIへ入力文を送信することへの明示同意
+  // 🔵 青信号: NFR-102の初回同意要件に基づく
+  final bool hasAcceptedAIPrivacyPolicy;
+
+  // 【コンストラクタ】: デフォルト値を設定（medium、light、normal、normal、false）
   // 【デフォルト値】: interfaces.dartで定義されたデフォルト値
   // 🔵 青信号: REQ-801、REQ-803、REQ-404、REQ-903のデフォルト値定義に基づく
   const AppSettings({
@@ -36,6 +40,7 @@ class AppSettings {
     this.theme = AppTheme.light,
     this.ttsSpeed = TTSSpeed.normal,
     this.aiPoliteness = PolitenessLevel.normal,
+    this.hasAcceptedAIPrivacyPolicy = false,
   });
 
   /// 【機能概要】: 設定の一部を変更した新しいインスタンスを生成
@@ -47,6 +52,7 @@ class AppSettings {
     AppTheme? theme,
     TTSSpeed? ttsSpeed,
     PolitenessLevel? aiPoliteness,
+    bool? hasAcceptedAIPrivacyPolicy,
   }) {
     // 【実装内容】: 指定されたフィールドのみ更新し、それ以外は既存値を保持
     // 【null安全性】: Dart Null Safetyに準拠した実装
@@ -56,6 +62,8 @@ class AppSettings {
       theme: theme ?? this.theme,
       ttsSpeed: ttsSpeed ?? this.ttsSpeed,
       aiPoliteness: aiPoliteness ?? this.aiPoliteness,
+      hasAcceptedAIPrivacyPolicy:
+          hasAcceptedAIPrivacyPolicy ?? this.hasAcceptedAIPrivacyPolicy,
     );
   }
 
@@ -73,6 +81,7 @@ class AppSettings {
       'theme': theme.name,
       'tts_speed': ttsSpeed.name,
       'ai_politeness': aiPoliteness.name,
+      'ai_privacy_consent': hasAcceptedAIPrivacyPolicy,
     };
   }
 
@@ -142,6 +151,7 @@ class AppSettings {
       theme: theme,
       ttsSpeed: ttsSpeed,
       aiPoliteness: aiPoliteness,
+      hasAcceptedAIPrivacyPolicy: json['ai_privacy_consent'] as bool? ?? false,
     );
   }
 }

--- a/frontend/kotonoha_app/lib/features/settings/providers/settings_provider.dart
+++ b/frontend/kotonoha_app/lib/features/settings/providers/settings_provider.dart
@@ -83,6 +83,8 @@ class SettingsNotifier extends AsyncNotifier<AppSettings> {
         PolitenessLevel.values,
         PolitenessLevel.normal,
       );
+      final hasAcceptedAIPrivacyPolicy =
+          _prefs!.getBool('ai_privacy_consent') ?? false;
 
       // 【設定復元】: index値からenumに変換してAppSettingsインスタンスを生成
       // 【境界値チェック】: index値が範囲外の場合はデフォルト値を使用
@@ -92,6 +94,7 @@ class SettingsNotifier extends AsyncNotifier<AppSettings> {
         theme: AppTheme.values[themeIndex],
         ttsSpeed: ttsSpeed,
         aiPoliteness: aiPoliteness,
+        hasAcceptedAIPrivacyPolicy: hasAcceptedAIPrivacyPolicy,
       );
     } catch (e) {
       // 【エラーハンドリング】: SharedPreferences初期化失敗時の処理
@@ -314,6 +317,24 @@ class SettingsNotifier extends AsyncNotifier<AppSettings> {
     } catch (e) {
       // 【エラーハンドリング】: 保存失敗時の処理
       // 【楽観的更新維持】: 保存失敗してもUI状態は更新済み
+    }
+  }
+
+  /// 【機能概要】: AI変換のプライバシー同意状態を変更する
+  /// 【実装方針】: 明示同意をSharedPreferencesへ永続化し、次回以降の再確認を省略する
+  /// 🔵 信頼性レベル: NFR-102（AI変換時の明示的な同意取得）に基づく
+  Future<void> setAIPrivacyConsent(bool accepted) async {
+    final currentSettings = state.asData?.value;
+    if (currentSettings == null) return;
+
+    state = AsyncValue.data(
+      currentSettings.copyWith(hasAcceptedAIPrivacyPolicy: accepted),
+    );
+
+    try {
+      await _prefs?.setBool('ai_privacy_consent', accepted);
+    } catch (e) {
+      // 保存失敗時も現在セッションでは同意状態を保持する。
     }
   }
 }

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -7,6 +7,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 FLUTTER_APP_DIR="$PROJECT_ROOT/frontend/kotonoha_app"
+API_BASE_URL="${API_BASE_URL:-http://localhost:8000}"
+AI_API_KEY="${AI_API_KEY:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -24,6 +26,25 @@ echo_warn() {
 
 echo_error() {
     echo -e "${RED}[ERROR]${NC} $1"
+}
+
+dart_define_flags() {
+    local flags="--dart-define=API_BASE_URL=$API_BASE_URL"
+
+    if [ -n "$AI_API_KEY" ]; then
+        flags="$flags --dart-define=AI_API_KEY=$AI_API_KEY"
+    fi
+
+    echo "$flags"
+}
+
+print_build_config() {
+    echo_info "API Base URL: $API_BASE_URL"
+    if [ -n "$AI_API_KEY" ]; then
+        echo_info "AI API Key: configured"
+    else
+        echo_warn "AI API Key: not configured"
+    fi
 }
 
 # Check Flutter installation
@@ -64,7 +85,8 @@ get_dependencies() {
 build_apk_debug() {
     echo_info "Building debug APK..."
     cd "$FLUTTER_APP_DIR"
-    flutter build apk --debug --flavor production
+    print_build_config
+    flutter build apk --debug --flavor production $(dart_define_flags)
     echo_info "Debug APK built: build/app/outputs/flutter-apk/app-production-debug.apk"
 }
 
@@ -72,7 +94,8 @@ build_apk_debug() {
 build_apk_release() {
     echo_info "Building release APK..."
     cd "$FLUTTER_APP_DIR"
-    flutter build apk --release --flavor production --obfuscate --split-debug-info=build/debug-info
+    print_build_config
+    flutter build apk --release --flavor production --obfuscate --split-debug-info=build/debug-info $(dart_define_flags)
     echo_info "Release APK built: build/app/outputs/flutter-apk/app-production-release.apk"
 }
 
@@ -80,7 +103,8 @@ build_apk_release() {
 build_bundle() {
     echo_info "Building App Bundle for Google Play..."
     cd "$FLUTTER_APP_DIR"
-    flutter build appbundle --release --flavor production --obfuscate --split-debug-info=build/debug-info
+    print_build_config
+    flutter build appbundle --release --flavor production --obfuscate --split-debug-info=build/debug-info $(dart_define_flags)
     echo_info "App Bundle built: build/app/outputs/bundle/productionRelease/app-production-release.aab"
 }
 
@@ -88,7 +112,8 @@ build_bundle() {
 build_internal() {
     echo_info "Building internal test APK..."
     cd "$FLUTTER_APP_DIR"
-    flutter build apk --release --flavor internal
+    print_build_config
+    flutter build apk --release --flavor internal $(dart_define_flags)
     echo_info "Internal APK built: build/app/outputs/flutter-apk/app-internal-release.apk"
 }
 

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -22,6 +22,18 @@ cd "$PROJECT_ROOT/frontend/kotonoha_app"
 BUILD_MODE="release"
 ARCHIVE=false
 TESTFLIGHT=false
+API_BASE_URL="${API_BASE_URL:-http://localhost:8000}"
+AI_API_KEY="${AI_API_KEY:-}"
+
+dart_define_flags() {
+    local flags="--dart-define=API_BASE_URL=$API_BASE_URL"
+
+    if [ -n "$AI_API_KEY" ]; then
+        flags="$flags --dart-define=AI_API_KEY=$AI_API_KEY"
+    fi
+
+    echo "$flags"
+}
 
 # 引数解析
 for arg in "$@"; do
@@ -56,6 +68,12 @@ echo "================================================"
 echo "Mode: $BUILD_MODE"
 echo "Archive: $ARCHIVE"
 echo "TestFlight: $TESTFLIGHT"
+echo "API Base URL: $API_BASE_URL"
+if [ -n "$AI_API_KEY" ]; then
+    echo "AI API Key: configured"
+else
+    echo "AI API Key: not configured"
+fi
 echo "================================================"
 
 # Flutter依存関係の更新
@@ -82,7 +100,8 @@ if [ "$ARCHIVE" = true ]; then
     flutter build ipa --release \
         --export-options-plist=ios/ExportOptions.plist \
         --obfuscate \
-        --split-debug-info=build/ios/symbols
+        --split-debug-info=build/ios/symbols \
+        $(dart_define_flags)
 
     # ビルド成果物の確認
     IPA_PATH="build/ios/ipa/*.ipa"
@@ -108,13 +127,13 @@ else
 
     case $BUILD_MODE in
         debug)
-            flutter build ios --debug --no-codesign
+            flutter build ios --debug --no-codesign $(dart_define_flags)
             ;;
         release)
-            flutter build ios --release
+            flutter build ios --release $(dart_define_flags)
             ;;
         profile)
-            flutter build ios --profile
+            flutter build ios --profile $(dart_define_flags)
             ;;
     esac
 

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -46,6 +46,8 @@ PWA_ENABLED=true
 TREE_SHAKE_ICONS=true
 PORT=8080
 WASM_BUILD=false
+API_BASE_URL="${API_BASE_URL:-http://localhost:8000}"
+AI_API_KEY="${AI_API_KEY:-}"
 
 # Project paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -142,6 +144,16 @@ build_common_flags() {
     echo "$flags"
 }
 
+build_dart_define_flags() {
+    local flags="--dart-define=API_BASE_URL=$API_BASE_URL"
+
+    if [ -n "$AI_API_KEY" ]; then
+        flags="$flags --dart-define=AI_API_KEY=$AI_API_KEY"
+    fi
+
+    echo "$flags"
+}
+
 # Build commands
 build_debug() {
     print_header "Building Flutter Web (Debug)"
@@ -149,14 +161,22 @@ build_debug() {
     cd "$FLUTTER_APP_DIR"
 
     local common_flags=$(build_common_flags)
+    local dart_define_flags=$(build_dart_define_flags)
 
     echo "Base Href: $BASE_HREF"
+    echo "API Base URL: $API_BASE_URL"
+    if [ -n "$AI_API_KEY" ]; then
+        echo "AI API Key: configured"
+    else
+        echo "AI API Key: not configured"
+    fi
     echo "PWA: $PWA_ENABLED"
     echo "WASM: $WASM_BUILD"
 
     flutter build web \
         --debug \
         $common_flags \
+        $dart_define_flags \
         --source-maps \
         --dart-define=FLUTTER_WEB_DEBUG_MODE=true
 
@@ -169,14 +189,22 @@ build_release() {
     cd "$FLUTTER_APP_DIR"
 
     local common_flags=$(build_common_flags)
+    local dart_define_flags=$(build_dart_define_flags)
 
     echo "Base Href: $BASE_HREF"
+    echo "API Base URL: $API_BASE_URL"
+    if [ -n "$AI_API_KEY" ]; then
+        echo "AI API Key: configured"
+    else
+        echo "AI API Key: not configured"
+    fi
     echo "PWA: $PWA_ENABLED"
     echo "WASM: $WASM_BUILD"
 
     flutter build web \
         --release \
         $common_flags \
+        $dart_define_flags \
         --dart-define=FLUTTER_WEB_DEBUG_MODE=false
 
     # Show build size
@@ -194,10 +222,12 @@ build_profile() {
     cd "$FLUTTER_APP_DIR"
 
     local common_flags=$(build_common_flags)
+    local dart_define_flags=$(build_dart_define_flags)
 
     flutter build web \
         --profile \
         $common_flags \
+        $dart_define_flags \
         --source-maps
 
     print_success "Profile build completed: $BUILD_DIR"


### PR DESCRIPTION
## Summary

Fixes the major code review findings around AI conversion readiness:

- wires AI conversion into the home screen, including politeness selection, result adoption, regeneration, and original-text fallback
- adds first-use AI privacy consent persistence before sending text to the backend
- passes `API_BASE_URL` and `AI_API_KEY` through Flutter clients, local build scripts, and GitHub Actions
- makes backend development/test settings importable without a `.env` while rejecting weak defaults in production
- removes plaintext AI input/output snippets from backend logs and legacy model reprs
- improves frontend API error parsing for auth, validation, timeout, and global error response shapes
- fixes misleading static rate-limit remaining headers

## Validation

- `backend/.venv/bin/ruff check backend/app`
- focused backend tests: `76 passed, 3 skipped`
- `flutter analyze --no-fatal-infos` (passes; existing info-level lint items remain)
- `flutter test` (`1457 passed, 1 skipped`)

Backend full test suite still depends on a prepared local PostgreSQL role/database. In this environment it fails with `role "kotonoha_user" does not exist`, matching the local DB setup issue observed during review.