### PR TITLE
改善: AIクライアントの堅牢化（型付き例外・レスポンス検証・httpxクローズ）

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     yield
     # 終了時の処理
     logger.info(f"Shutting down {settings.PROJECT_NAME}...")
+    # AIクライアントのHTTPリソースを明示的にクローズ
+    from app.utils import ai_client as ai_client_module
+
+    await ai_client_module.ai_client.aclose()
 
 
 # FastAPIアプリケーション作成

--- a/backend/app/utils/ai_client.py
+++ b/backend/app/utils/ai_client.py
@@ -12,6 +12,7 @@ TASK-0026: 外部AI API連携実装（Claude/GPT プロキシ）
   - エラーハンドリング（タイムアウト、レート制限等）
 """
 
+import importlib
 import logging
 import time
 from typing import Literal
@@ -28,6 +29,107 @@ logger = logging.getLogger(__name__)
 
 # 丁寧さレベルの型定義
 PolitenessLevel = Literal["casual", "normal", "polite"]
+
+# プロバイダーSDKの型付き例外のキャッシュ（(タイムアウト型, レート制限型)）
+_PROVIDER_EXCEPTION_TYPES: tuple[tuple[type, ...], tuple[type, ...]] | None = None
+
+
+def _provider_exception_types() -> tuple[tuple[type, ...], tuple[type, ...]]:
+    """インストール済みSDKのタイムアウト/レート制限例外型を収集する。
+
+    anthropic / openai SDKは `APITimeoutError` `RateLimitError` などの型付き例外を
+    提供する。文字列マッチではなく型で判定するために、利用可能な型を一度だけ収集する。
+
+    Returns:
+        (タイムアウト例外型のタプル, レート制限例外型のタプル)
+    """
+    global _PROVIDER_EXCEPTION_TYPES
+    if _PROVIDER_EXCEPTION_TYPES is not None:
+        return _PROVIDER_EXCEPTION_TYPES
+
+    timeout_types: list[type] = []
+    rate_types: list[type] = []
+    for module_name in ("anthropic", "openai"):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        timeout_type = getattr(module, "APITimeoutError", None)
+        if isinstance(timeout_type, type):
+            timeout_types.append(timeout_type)
+        rate_type = getattr(module, "RateLimitError", None)
+        if isinstance(rate_type, type):
+            rate_types.append(rate_type)
+
+    _PROVIDER_EXCEPTION_TYPES = (tuple(timeout_types), tuple(rate_types))
+    return _PROVIDER_EXCEPTION_TYPES
+
+
+def _map_provider_exception(error: Exception, provider_label: str) -> Exception:
+    """プロバイダーSDKの例外を、対応するアプリ例外へマッピングする。
+
+    型付き例外（SDKの APITimeoutError / RateLimitError / APIStatusError(429)）を優先し、
+    判定できない場合のみ文字列ヒューリスティックにフォールバックする。これにより
+    ローカライズやSDKのメッセージ変更でタイムアウト/レート制限の判定が外れるのを防ぐ。
+
+    Args:
+        error: SDKが送出した例外
+        provider_label: ログ/メッセージ用のプロバイダー名（例: "Claude"）
+
+    Returns:
+        Exception: AITimeoutException / AIRateLimitException / AIConversionException
+    """
+    timeout_types, rate_types = _provider_exception_types()
+    message = str(error)
+
+    if timeout_types and isinstance(error, timeout_types):
+        return AITimeoutException(f"{provider_label} API timeout: {message}")
+    if rate_types and isinstance(error, rate_types):
+        return AIRateLimitException(f"{provider_label} API rate limit: {message}")
+
+    # APIStatusError 等は status_code を持つ
+    status_code = getattr(error, "status_code", None)
+    if status_code == 429:
+        return AIRateLimitException(f"{provider_label} API rate limit: {message}")
+
+    # フォールバック: 文字列ヒューリスティック
+    lowered = message.lower()
+    if "timeout" in lowered:
+        return AITimeoutException(f"{provider_label} API timeout: {message}")
+    if "rate" in lowered or "429" in message:
+        return AIRateLimitException(f"{provider_label} API rate limit: {message}")
+
+    return AIConversionException(f"{provider_label} API error: {message}")
+
+
+def _extract_anthropic_text(response: object) -> str:
+    """Anthropicレスポンスから本文テキストを安全に取り出す。
+
+    空content・textブロック以外・空文字の場合は AIConversionException を送出し、
+    AttributeError/IndexError による未捕捉500を防ぐ。
+    """
+    content = getattr(response, "content", None)
+    if not content:
+        raise AIConversionException("Claude API returned empty content")
+    text = getattr(content[0], "text", None)
+    if not isinstance(text, str) or not text.strip():
+        raise AIConversionException("Claude API returned no text content")
+    return text.strip()
+
+
+def _extract_openai_text(response: object) -> str:
+    """OpenAIレスポンスから本文テキストを安全に取り出す。
+
+    空choices・content=None・空文字の場合は AIConversionException を送出する。
+    """
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise AIConversionException("OpenAI API returned no choices")
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", None)
+    if not isinstance(content, str) or not content.strip():
+        raise AIConversionException("OpenAI API returned empty content")
+    return content.strip()
 
 
 class AIClient:
@@ -56,6 +158,8 @@ class AIClient:
         """
         self.anthropic_client = None
         self.openai_client = None
+        # 明示生成した httpx クライアントを保持し、shutdown 時にクローズする
+        self._anthropic_http_client = None
 
         # Anthropic クライアント初期化
         if settings.ANTHROPIC_API_KEY:
@@ -65,6 +169,7 @@ class AIClient:
 
                 # httpxクライアントを明示的に作成（プロキシ設定を無視）
                 http_client = httpx.AsyncClient(timeout=settings.AI_API_TIMEOUT)
+                self._anthropic_http_client = http_client
                 self.anthropic_client = AsyncAnthropic(
                     api_key=settings.ANTHROPIC_API_KEY,
                     http_client=http_client,
@@ -166,7 +271,7 @@ class AIClient:
                 messages=[{"role": "user", "content": prompt}],
             )
 
-            converted_text = response.content[0].text.strip()
+            converted_text = _extract_anthropic_text(response)
             conversion_time_ms = int((time.time() - start_time) * 1000)
 
             logger.info(
@@ -176,20 +281,17 @@ class AIClient:
 
             return converted_text, conversion_time_ms
 
+        except (
+            AIProviderException,
+            AITimeoutException,
+            AIRateLimitException,
+            AIConversionException,
+        ):
+            # 既にマッピング済みのアプリ例外（空content検証含む）はそのまま伝播
+            raise
         except Exception as e:
-            error_message = str(e)
-            logger.error(f"Claude API error: {error_message}")
-
-            # タイムアウト判定
-            if "timeout" in error_message.lower():
-                raise AITimeoutException(f"Claude API timeout: {error_message}") from e
-
-            # レート制限判定
-            if "rate" in error_message.lower() or "429" in error_message:
-                raise AIRateLimitException(f"Claude API rate limit: {error_message}") from e
-
-            # その他のエラー
-            raise AIConversionException(f"Claude API error: {error_message}") from e
+            logger.error(f"Claude API error: {e}")
+            raise _map_provider_exception(e, "Claude") from e
 
     async def convert_text_openai(
         self,
@@ -246,7 +348,7 @@ class AIClient:
                 temperature=0.7,
             )
 
-            converted_text = response.choices[0].message.content.strip()
+            converted_text = _extract_openai_text(response)
             conversion_time_ms = int((time.time() - start_time) * 1000)
 
             logger.info(
@@ -256,20 +358,16 @@ class AIClient:
 
             return converted_text, conversion_time_ms
 
+        except (
+            AIProviderException,
+            AITimeoutException,
+            AIRateLimitException,
+            AIConversionException,
+        ):
+            raise
         except Exception as e:
-            error_message = str(e)
-            logger.error(f"OpenAI API error: {error_message}")
-
-            # タイムアウト判定
-            if "timeout" in error_message.lower():
-                raise AITimeoutException(f"OpenAI API timeout: {error_message}") from e
-
-            # レート制限判定
-            if "rate" in error_message.lower() or "429" in error_message:
-                raise AIRateLimitException(f"OpenAI API rate limit: {error_message}") from e
-
-            # その他のエラー
-            raise AIConversionException(f"OpenAI API error: {error_message}") from e
+            logger.error(f"OpenAI API error: {e}")
+            raise _map_provider_exception(e, "OpenAI") from e
 
     async def convert_text(
         self,
@@ -365,7 +463,7 @@ class AIClient:
                     messages=[{"role": "user", "content": prompt}],
                 )
 
-                converted_text = response.content[0].text.strip()
+                converted_text = _extract_anthropic_text(response)
 
             elif provider == "openai":
                 if not self.openai_client:
@@ -384,7 +482,7 @@ class AIClient:
                     temperature=0.9,  # 多様性を高める
                 )
 
-                converted_text = response.choices[0].message.content.strip()
+                converted_text = _extract_openai_text(response)
 
             else:
                 raise AIProviderException(f"Unknown AI provider: {provider}")
@@ -398,22 +496,39 @@ class AIClient:
 
             return converted_text, conversion_time_ms
 
-        except AIProviderException:
+        except (
+            AIProviderException,
+            AITimeoutException,
+            AIRateLimitException,
+            AIConversionException,
+        ):
             raise
         except Exception as e:
-            error_message = str(e)
-            logger.error(f"AI regeneration error: {error_message}")
+            logger.error(f"AI regeneration error: {e}")
+            raise _map_provider_exception(e, "AI") from e
 
-            # タイムアウト判定
-            if "timeout" in error_message.lower():
-                raise AITimeoutException(f"AI API timeout: {error_message}") from e
+    async def aclose(self) -> None:
+        """保持しているHTTPクライアントを明示的にクローズする。
 
-            # レート制限判定
-            if "rate" in error_message.lower() or "429" in error_message:
-                raise AIRateLimitException(f"AI API rate limit: {error_message}") from e
+        明示生成した httpx.AsyncClient はそのままだとクローズされず、
+        「Unclosed client」警告やリソースリークの原因になる。アプリの
+        shutdown（lifespan）から呼び出してクリーンアップする。
+        """
+        if self._anthropic_http_client is not None:
+            try:
+                await self._anthropic_http_client.aclose()
+            except Exception as e:  # クローズ失敗はログのみ（shutdownを阻害しない）
+                logger.warning(f"Failed to close Anthropic HTTP client: {e}")
+            finally:
+                self._anthropic_http_client = None
 
-            # その他のエラー
-            raise AIConversionException(f"AI API error: {error_message}") from e
+        if self.openai_client is not None:
+            close = getattr(self.openai_client, "close", None)
+            if callable(close):
+                try:
+                    await close()
+                except Exception as e:
+                    logger.warning(f"Failed to close OpenAI client: {e}")
 
 
 # シングルトンインスタンス

--- a/backend/tests/test_ai_client_robustness.py
+++ b/backend/tests/test_ai_client_robustness.py
@@ -1,0 +1,171 @@
+"""
+AIクライアント堅牢化テスト
+
+ai_client.py の以下の堅牢化を検証する:
+- SDKの型付き例外（APITimeoutError / RateLimitError）→ アプリ例外への正確なマッピング
+- 空content/不正レスポンスの検証（None参照による未捕捉500の防止）
+- 明示生成した httpx クライアントの aclose によるクリーンアップ
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import anthropic
+import httpx
+import openai
+import pytest
+
+from app.utils.ai_client import (
+    AIClient,
+    _extract_anthropic_text,
+    _extract_openai_text,
+    _map_provider_exception,
+)
+from app.utils.exceptions import (
+    AIConversionException,
+    AIRateLimitException,
+    AITimeoutException,
+)
+
+_REQ = httpx.Request("POST", "http://test")
+
+
+# ============================================================
+# 例外マッピング（型付き優先）
+# ============================================================
+
+
+class TestMapProviderException:
+    def test_anthropic_timeout_maps_to_ai_timeout(self):
+        err = anthropic.APITimeoutError(request=_REQ)
+        mapped = _map_provider_exception(err, "Claude")
+        assert isinstance(mapped, AITimeoutException)
+
+    def test_anthropic_rate_limit_maps_to_ai_rate_limit(self):
+        err = anthropic.RateLimitError(
+            "rate limited", response=httpx.Response(429, request=_REQ), body=None
+        )
+        mapped = _map_provider_exception(err, "Claude")
+        assert isinstance(mapped, AIRateLimitException)
+
+    def test_openai_timeout_maps_to_ai_timeout(self):
+        err = openai.APITimeoutError(request=_REQ)
+        mapped = _map_provider_exception(err, "OpenAI")
+        assert isinstance(mapped, AITimeoutException)
+
+    def test_status_code_429_maps_to_rate_limit(self):
+        err = Exception("boom")
+        err.status_code = 429  # type: ignore[attr-defined]
+        mapped = _map_provider_exception(err, "AI")
+        assert isinstance(mapped, AIRateLimitException)
+
+    def test_string_fallback_timeout(self):
+        mapped = _map_provider_exception(Exception("Connection timeout occurred"), "AI")
+        assert isinstance(mapped, AITimeoutException)
+
+    def test_generic_error_maps_to_conversion_error(self):
+        mapped = _map_provider_exception(Exception("something else"), "AI")
+        assert isinstance(mapped, AIConversionException)
+
+
+# ============================================================
+# レスポンス本文抽出（空/不正レスポンス検証）
+# ============================================================
+
+
+class TestExtractText:
+    def test_anthropic_valid(self):
+        response = SimpleNamespace(content=[SimpleNamespace(text="  こんにちは  ")])
+        assert _extract_anthropic_text(response) == "こんにちは"
+
+    def test_anthropic_empty_content_raises(self):
+        with pytest.raises(AIConversionException):
+            _extract_anthropic_text(SimpleNamespace(content=[]))
+
+    def test_anthropic_no_text_attr_raises(self):
+        response = SimpleNamespace(content=[SimpleNamespace(text=None)])
+        with pytest.raises(AIConversionException):
+            _extract_anthropic_text(response)
+
+    def test_openai_valid(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=" ありがとう "))]
+        )
+        assert _extract_openai_text(response) == "ありがとう"
+
+    def test_openai_no_choices_raises(self):
+        with pytest.raises(AIConversionException):
+            _extract_openai_text(SimpleNamespace(choices=[]))
+
+    def test_openai_none_content_raises(self):
+        response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=None))])
+        with pytest.raises(AIConversionException):
+            _extract_openai_text(response)
+
+
+# ============================================================
+# 変換メソッドの統合（型付き例外→アプリ例外）
+# ============================================================
+
+
+class TestConvertExceptionMapping:
+    @pytest.mark.asyncio
+    async def test_anthropic_timeout_raises_ai_timeout(self):
+        client = AIClient()
+        client.anthropic_client = AsyncMock()
+        client.anthropic_client.messages.create = AsyncMock(
+            side_effect=anthropic.APITimeoutError(request=_REQ)
+        )
+        with pytest.raises(AITimeoutException):
+            await client.convert_text_anthropic("テスト入力", "normal")
+
+    @pytest.mark.asyncio
+    async def test_anthropic_empty_content_raises_conversion(self):
+        client = AIClient()
+        client.anthropic_client = AsyncMock()
+        client.anthropic_client.messages.create = AsyncMock(
+            return_value=SimpleNamespace(content=[])
+        )
+        with pytest.raises(AIConversionException):
+            await client.convert_text_anthropic("テスト入力", "normal")
+
+    @pytest.mark.asyncio
+    async def test_openai_rate_limit_raises_ai_rate_limit(self):
+        client = AIClient()
+        client.openai_client = AsyncMock()
+        client.openai_client.chat.completions.create = AsyncMock(
+            side_effect=openai.RateLimitError(
+                "rate", response=httpx.Response(429, request=_REQ), body=None
+            )
+        )
+        with pytest.raises(AIRateLimitException):
+            await client.convert_text_openai("テスト入力", "normal")
+
+
+# ============================================================
+# aclose によるクリーンアップ
+# ============================================================
+
+
+class TestAClose:
+    @pytest.mark.asyncio
+    async def test_aclose_closes_http_and_openai_clients(self):
+        client = AIClient()
+        http_client = AsyncMock()
+        client._anthropic_http_client = http_client
+        openai_client = AsyncMock()
+        client.openai_client = openai_client
+
+        await client.aclose()
+
+        http_client.aclose.assert_awaited_once()
+        openai_client.close.assert_awaited_once()
+        assert client._anthropic_http_client is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_is_safe_when_nothing_initialized(self):
+        client = AIClient()
+        client._anthropic_http_client = None
+        client.openai_client = None
+        # 例外を投げずに完了すること
+        await client.aclose()


### PR DESCRIPTION
## 概要
コードレビュー(High)で指摘した AIクライアントの堅牢性問題を修正します。

## 変更内容
### 1. 型付きSDK例外による判定（文字列マッチの脆弱性を解消）
- これまで `"timeout" in str(e)` / `"429" in str(e)` で判定しており、ローカライズ・SDK更新・メッセージ変更で容易に外れ、504/429であるべきエラーが500に化けていました。
- `_map_provider_exception()` を新設し、anthropic/openai の `APITimeoutError` / `RateLimitError` を `isinstance` で判定。`APIStatusError` の `status_code==429` も拾います。判定不能時のみ従来の文字列ヒューリスティックにフォールバック。

### 2. レスポンス本文の検証（None参照による未捕捉500の防止）
- `response.content[0].text` / `response.choices[0].message.content` は、空content・型違い・content=None で `AttributeError`/`IndexError`/`TypeError` を投げ得ました。
- `_extract_anthropic_text()` / `_extract_openai_text()` で空・不正レスポンスを検証し、`AIConversionException` として一貫処理します。

### 3. httpx クライアントのクローズ（リソースリーク防止）
- 明示生成した `httpx.AsyncClient` を保持し、`AIClient.aclose()` でクローズ。`main.py` の lifespan shutdown から呼び出します（「Unclosed client」警告/リソースリーク防止）。

## テスト
- 追加 `tests/test_ai_client_robustness.py`（型付き例外マッピング・空/不正レスポンス検証・aclose）。
- 全体: **304 passed, 5 skipped**、ruff / black クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)