### PR TITLE
改善: DBスキーマ整合性（enum大小文字統一・server_default・index・autogenerate健全化）

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -52,6 +52,8 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
     )
 
     with context.begin_transaction():
@@ -71,7 +73,12 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/backend/alembic/versions/ac3a7c362e68_create_ai_conversion_history_table_with_.py
+++ b/backend/alembic/versions/ac3a7c362e68_create_ai_conversion_history_table_with_.py
@@ -92,4 +92,9 @@ def downgrade() -> None:
     # 【テーブル削除】: ai_conversion_historyテーブルを削除
     # 🔵 database-schema.sqlに基づくロールバック処理
     op.drop_table("ai_conversion_history")
+
+    # 【ENUM型削除】: create_constraint=True により作成された ENUM 型を明示的に削除する。
+    # drop_table だけでは型が残り、再 upgrade 時に「type already exists」で失敗するため
+    # （冪等性・再現性の確保）。
+    op.execute("DROP TYPE IF EXISTS politeness_level_enum")
     # ### end Alembic commands ###

--- a/backend/alembic/versions/c1a2b3d4e5f6_lowercase_politeness_level_enum.py
+++ b/backend/alembic/versions/c1a2b3d4e5f6_lowercase_politeness_level_enum.py
@@ -1,0 +1,45 @@
+"""lowercase politeness_level_enum values
+
+ai_conversion_history の politeness_level_enum はメンバー名（CASUAL/NORMAL/POLITE,
+大文字）で作成されていたが、ai_conversion_logs は小文字（casual/normal/polite）で
+保持しており、同一概念がテーブル間で大文字/小文字に分かれていた。
+
+本マイグレーションで ENUM 値を小文字へリネームし、モデル側の values_callable
+（.value=小文字を保存）と一致させてデータ表現を統一する。
+
+PostgreSQL 10+ の ALTER TYPE ... RENAME VALUE を使用（既存データを保持したまま改名）。
+
+Revision ID: c1a2b3d4e5f6
+Revises: b5d6e2f8c9a0
+Create Date: 2026-06-14
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1a2b3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "b5d6e2f8c9a0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (旧値, 新値) のペア
+_RENAMES = (
+    ("CASUAL", "casual"),
+    ("NORMAL", "normal"),
+    ("POLITE", "polite"),
+)
+
+
+def upgrade() -> None:
+    """ENUM値を大文字から小文字へリネームする。"""
+    for old, new in _RENAMES:
+        op.execute(f"ALTER TYPE politeness_level_enum RENAME VALUE '{old}' TO '{new}'")
+
+
+def downgrade() -> None:
+    """ENUM値を小文字から大文字へ戻す。"""
+    for old, new in _RENAMES:
+        op.execute(f"ALTER TYPE politeness_level_enum RENAME VALUE '{new}' TO '{old}'")

--- a/backend/app/models/ai_conversion_history.py
+++ b/backend/app/models/ai_conversion_history.py
@@ -36,7 +36,7 @@ import enum
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import DateTime, Enum, Index, Integer, Text
+from sqlalchemy import DateTime, Enum, Index, Integer, Text, text
 from sqlalchemy.dialects.postgresql import UUID as PostgreSQL_UUID  # noqa: N811
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
@@ -82,10 +82,10 @@ class AIConversionHistory(Base):
         # 【created_at降順インデックス】: 履歴を新しい順に取得するための最適化
         # 【パフォーマンス】: 時系列検索クエリ（ORDER BY created_at DESC）の高速化
         # 🔵 database-schema.sql（line 54-60）に基づくインデックス定義
+        # マイグレーション（式インデックス）と表現を揃え、autogenerateの差分を防ぐ
         Index(
             "idx_ai_conversion_created_at",
-            "created_at",
-            postgresql_ops={"created_at": "DESC"},
+            text("created_at DESC"),
         ),
         # 【user_session_idインデックス】: セッションごとの履歴取得の最適化
         # 【パフォーマンス】: WHERE user_session_id = ?クエリの高速化
@@ -116,7 +116,14 @@ class AIConversionHistory(Base):
     # 【テスト対応】: B-4～B-6（Enum値テスト）、E-1（不正なEnum値テスト）を検証
     # 🔵 要件定義書（line 57）、database-schema.sql（line 39-44）に基づく
     politeness_level: Mapped[PolitenessLevel] = mapped_column(
-        Enum(PolitenessLevel, name="politeness_level_enum", create_constraint=True),
+        Enum(
+            PolitenessLevel,
+            name="politeness_level_enum",
+            create_constraint=True,
+            # メンバー名(CASUAL等)ではなく .value(casual等)をDBに保存し、
+            # ai_conversion_logs（小文字String）と表現を統一する
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
         nullable=False,
     )
 

--- a/backend/app/models/ai_conversion_logs.py
+++ b/backend/app/models/ai_conversion_logs.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -45,10 +46,10 @@ class AIConversionLog(Base):
             name="check_politeness_level",
         ),
         # 【created_at降順インデックス】: 時系列検索用インデックス
+        # マイグレーション（式インデックス）と表現を揃え、autogenerateの差分を防ぐ
         Index(
             "idx_ai_conversion_logs_created_at",
-            "created_at",
-            postgresql_ops={"created_at": "DESC"},
+            text("created_at DESC"),
         ),
         # 【input_text_hashインデックス】: ハッシュ検索用インデックス
         Index("idx_ai_conversion_logs_hash", "input_text_hash"),
@@ -79,7 +80,9 @@ class AIConversionLog(Base):
     ai_provider: Mapped[str | None] = mapped_column(String(50), nullable=True, default="anthropic")
 
     # 【必須フィールド】: 成功・失敗フラグ（デフォルト: True）
-    is_success: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_success: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
 
     # 【オプションフィールド】: エラーメッセージ（失敗時のみ）
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/error_logs.py
+++ b/backend/app/models/error_logs.py
@@ -9,7 +9,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Index, Integer, String, Text
+from sqlalchemy import DateTime, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -31,10 +31,10 @@ class ErrorLog(Base):
         # 【error_typeインデックス】: エラータイプ別検索用インデックス
         Index("idx_error_logs_type", "error_type"),
         # 【created_at降順インデックス】: 時系列検索用インデックス
+        # マイグレーション（式インデックス）と表現を揃え、autogenerateの差分を防ぐ
         Index(
             "idx_error_logs_created_at",
-            "created_at",
-            postgresql_ops={"created_at": "DESC"},
+            text("created_at DESC"),
         ),
     )
 

--- a/backend/tests/test_db_schema_consistency.py
+++ b/backend/tests/test_db_schema_consistency.py
@@ -1,0 +1,38 @@
+"""
+DBスキーマ整合性テスト（PR6: データ整合性/マイグレーション）
+
+- politeness_level ENUM がテーブル間で小文字に統一されていること
+- is_success にサーバーデフォルトが設定されていること（モデル/マイグレーション一致）
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.models.ai_conversion_logs import AIConversionLog
+
+
+class TestServerDefaults:
+    def test_is_success_has_server_default(self):
+        """is_success に server_default が設定されている（マイグレーションと一致）。"""
+        column = AIConversionLog.__table__.c.is_success
+        assert column.server_default is not None
+
+
+class TestPolitenessEnumLowercase:
+    @pytest.mark.asyncio
+    async def test_enum_labels_are_lowercase(self, db_session):
+        """politeness_level_enum のラベルが小文字（casual/normal/polite）であること。
+
+        モデルの values_callable により、create_all/マイグレーションのいずれでも
+        小文字で型が作成されることを検証する（ai_conversion_logs の小文字Stringと統一）。
+        """
+        result = await db_session.execute(
+            text(
+                "SELECT enumlabel FROM pg_enum e "
+                "JOIN pg_type t ON e.enumtypid = t.oid "
+                "WHERE t.typname = 'politeness_level_enum' "
+                "ORDER BY e.enumsortorder"
+            )
+        )
+        labels = [row[0] for row in result.fetchall()]
+        assert labels == ["casual", "normal", "polite"]


### PR DESCRIPTION
## 概要
コードレビュー(High/Medium)で指摘した、モデルとマイグレーションの不整合を解消します。`alembic check` で **差分ゼロ**（"No new upgrade operations detected"）を達成しました。

## 変更内容
### 1. politeness_level の大文字/小文字をテーブル間で統一 (High)
- `ai_conversion_history` は `Enum(PolitenessLevel)` がメンバー名（`CASUAL/NORMAL/POLITE`）でDB保存される一方、`ai_conversion_logs` は小文字（`casual/...`）でした。
- モデルに `values_callable`（`.value`=小文字を保存）を追加し、新規マイグレーション `c1a2b3d4e5f6` で `ALTER TYPE ... RENAME VALUE` により既存ENUM値を小文字へ改名（データ保持・PG10+）。

### 2. is_success の server_default 不一致 (High)
- モデルに `server_default=text("true")` を追加し、マイグレーション(`b5d6e2f8c9a0`)と一致。

### 3. created_at DESC インデックスの表現統一 (Medium)
- モデルの `postgresql_ops` 形式を、マイグレーションと同じ式インデックス `text("created_at DESC")` に統一（3テーブル）。

### 4. autogenerate の精度向上 (Medium)
- `env.py` の両 `context.configure` に `compare_type=True` / `compare_server_default=True` を追加。

### 5. downgrade の ENUM 型削除漏れ (Medium・冪等性バグ)
- `ac3a7c362e68` の downgrade に `DROP TYPE IF EXISTS politeness_level_enum` を追加。`drop_table` だけでは型が残り、downgrade→再upgradeが「type already exists」で失敗していました。

## 検証
- クリーンな `upgrade head` でENUM値が小文字（casual/normal/polite）。
- `downgrade base` → `upgrade head` の往復が成功（DROP TYPE修正で冪等）。
- `alembic check`: **No new upgrade operations detected**（モデル/スキーマ完全一致）。
- 全テスト **289 passed, 5 skipped**、ruff / black クリーン。
- スキーマ整合性の回帰テストを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)