### PR TITLE
修正: 履歴の読み上げ中表示(per-item)とProviderのリソースリーク(ref.onDispose)

### DIFF
--- a/frontend/kotonoha_app/lib/features/ai_conversion/providers/ai_conversion_provider.dart
+++ b/frontend/kotonoha_app/lib/features/ai_conversion/providers/ai_conversion_provider.dart
@@ -23,7 +23,10 @@ final aiConversionApiClientProvider = Provider<AIConversionApiClient>((ref) {
     defaultValue: 'http://localhost:8000',
   );
   const apiKey = String.fromEnvironment('AI_API_KEY');
-  return AIConversionApiClient(baseUrl: baseUrl, apiKey: apiKey);
+  final client = AIConversionApiClient(baseUrl: baseUrl, apiKey: apiKey);
+  // Provider破棄時にDioの接続リソースを解放（リソースリーク防止）
+  ref.onDispose(client.dio.close);
+  return client;
 });
 
 /// AI変換Providerの定義

--- a/frontend/kotonoha_app/lib/features/history/presentation/history_screen.dart
+++ b/frontend/kotonoha_app/lib/features/history/presentation/history_screen.dart
@@ -37,12 +37,24 @@ import 'constants/history_ui_constants.dart';
 /// - NFR-061-001: 50件を1秒以内に表示
 /// - NFR-061-004: タップターゲット44px以上
 /// - REQ-701: お気に入り追加機能
-class HistoryScreen extends ConsumerWidget {
+class HistoryScreen extends ConsumerStatefulWidget {
   /// 履歴画面を作成する。
   const HistoryScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HistoryScreen> createState() => _HistoryScreenState();
+}
+
+class _HistoryScreenState extends ConsumerState<HistoryScreen> {
+  /// 現在読み上げ中の履歴項目ID
+  ///
+  /// 【バグ修正】: 以前はTTSのspeaking状態を全カードに一律で渡していたため、
+  /// 1件を読み上げ中に全カードが停止アイコンに変わっていた。読み上げ対象の
+  /// 項目IDを保持し、その項目のみ読み上げ中表示にする。
+  String? _speakingId;
+
+  @override
+  Widget build(BuildContext context) {
     // 履歴状態を監視
     final historyState = ref.watch(historyProvider);
     final histories = historyState.histories;
@@ -50,8 +62,9 @@ class HistoryScreen extends ConsumerWidget {
     // TTS状態を監視
     final ttsState = ref.watch(ttsProvider);
 
-    // エラーメッセージを表示（FR-063-009）
+    // TTSの状態変更を監視
     ref.listen<TTSServiceState>(ttsProvider, (previous, next) {
+      // エラーメッセージを表示（FR-063-009）
       if (next.state == TTSState.error && next.errorMessage != null) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -59,6 +72,10 @@ class HistoryScreen extends ConsumerWidget {
             backgroundColor: Theme.of(context).colorScheme.error,
           ),
         );
+      }
+      // 読み上げが終了（speaking以外）したら読み上げ中ハイライトを解除
+      if (next.state != TTSState.speaking && _speakingId != null) {
+        setState(() => _speakingId = null);
       }
     });
 
@@ -70,7 +87,7 @@ class HistoryScreen extends ConsumerWidget {
             ? [
                 IconButton(
                   icon: const Icon(Icons.delete_sweep),
-                  onPressed: () => _showDeleteAllDialog(context, ref),
+                  onPressed: () => _showDeleteAllDialog(context),
                   tooltip: HistoryUIConstants.deleteAllTooltip,
                 ),
               ]
@@ -82,15 +99,17 @@ class HistoryScreen extends ConsumerWidget {
               itemCount: histories.length,
               itemBuilder: (context, index) {
                 final history = histories[index];
+                // 読み上げ中かつ対象項目が一致する場合のみ読み上げ中表示
+                final isSpeaking = ttsState.state == TTSState.speaking &&
+                    _speakingId == history.id;
                 return HistoryItemCard(
                   key: Key('history_item_card_${history.id}'),
                   history: history,
-                  isSpeaking: ttsState.state == TTSState.speaking,
-                  onTap: () => _onHistoryTap(ref, history.content),
-                  onDelete: () => _showDeleteDialog(context, ref, history.id),
-                  onStop: () => ref.read(ttsProvider.notifier).stop(),
-                  onLongPress: () =>
-                      _showContextMenu(context, ref, history.content),
+                  isSpeaking: isSpeaking,
+                  onTap: () => _onHistoryTap(history.id, history.content),
+                  onDelete: () => _showDeleteDialog(context, history.id),
+                  onStop: _onStop,
+                  onLongPress: () => _showContextMenu(context, history.content),
                 );
               },
             ),
@@ -101,20 +120,27 @@ class HistoryScreen extends ConsumerWidget {
   ///
   /// FR-061-006: 履歴項目をタップすると再読み上げを実行
   /// FR-063-008: 空文字列の読み上げを防止
-  void _onHistoryTap(WidgetRef ref, String content) {
+  void _onHistoryTap(String id, String content) {
     // 空文字列の場合は読み上げを実行しない
     if (content.isEmpty) {
       return;
     }
 
-    final ttsNotifier = ref.read(ttsProvider.notifier);
-    ttsNotifier.speak(content);
+    // 読み上げ対象の項目を記録（per-item表示のため）
+    setState(() => _speakingId = id);
+    ref.read(ttsProvider.notifier).speak(content);
+  }
+
+  /// 読み上げ停止処理
+  void _onStop() {
+    ref.read(ttsProvider.notifier).stop();
+    setState(() => _speakingId = null);
   }
 
   /// 個別削除確認ダイアログを表示
   ///
   /// FR-061-008: 削除時に確認ダイアログを表示
-  void _showDeleteDialog(BuildContext context, WidgetRef ref, String id) {
+  void _showDeleteDialog(BuildContext context, String id) {
     showDialog<void>(
       context: context,
       barrierDismissible: false, // FR-061-008: 誤操作防止
@@ -135,7 +161,7 @@ class HistoryScreen extends ConsumerWidget {
   /// 全削除確認ダイアログを表示
   ///
   /// FR-061-010: 全削除時に確認ダイアログを表示
-  void _showDeleteAllDialog(BuildContext context, WidgetRef ref) {
+  void _showDeleteAllDialog(BuildContext context) {
     showDialog<void>(
       context: context,
       barrierDismissible: false, // FR-061-010: 誤操作防止
@@ -156,7 +182,7 @@ class HistoryScreen extends ConsumerWidget {
   /// コンテキストメニューを表示
   ///
   /// REQ-701: 履歴からお気に入りに追加
-  void _showContextMenu(BuildContext context, WidgetRef ref, String content) {
+  void _showContextMenu(BuildContext context, String content) {
     showModalBottomSheet<void>(
       context: context,
       builder: (BuildContext sheetContext) {
@@ -168,7 +194,7 @@ class HistoryScreen extends ConsumerWidget {
                 title: const Text(HistoryUIConstants.addToFavoriteLabel),
                 onTap: () {
                   Navigator.of(sheetContext).pop();
-                  _addToFavorite(context, ref, content);
+                  _addToFavorite(context, content);
                 },
               ),
             ],
@@ -181,7 +207,7 @@ class HistoryScreen extends ConsumerWidget {
   /// お気に入りに追加
   ///
   /// REQ-701: お気に入り追加機能
-  void _addToFavorite(BuildContext context, WidgetRef ref, String content) {
+  void _addToFavorite(BuildContext context, String content) {
     final favoriteState = ref.read(favoriteProvider);
     final isDuplicate =
         favoriteState.favorites.any((f) => f.content == content);

--- a/frontend/kotonoha_app/lib/features/network/providers/network_provider.dart
+++ b/frontend/kotonoha_app/lib/features/network/providers/network_provider.dart
@@ -29,7 +29,11 @@ class NetworkNotifier extends Notifier<NetworkState> {
 
   /// 初期状態
   @override
-  NetworkState build() => NetworkState.checking;
+  NetworkState build() {
+    // Provider破棄時に接続状態リスナーを解放（StreamSubscriptionリーク防止）
+    ref.onDispose(cleanup);
+    return NetworkState.checking;
+  }
 
   /// ConnectivityServiceを取得
   ConnectivityService? get _connectivityService =>

--- a/frontend/kotonoha_app/lib/features/tts/providers/tts_provider.dart
+++ b/frontend/kotonoha_app/lib/features/tts/providers/tts_provider.dart
@@ -4,6 +4,8 @@
 /// Riverpod StateNotifierを使用したTTS状態管理
 library;
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import '../domain/models/tts_speed.dart';
@@ -92,6 +94,12 @@ class TTSNotifier extends Notifier<TTSServiceState> {
           tts: FlutterTts(),
           onStateChanged: _onServiceStateChanged,
         );
+    // Provider破棄時にネイティブTTSリソースを解放（リソースリーク防止）
+    // dispose内のネイティブ呼び出し失敗（例: テスト環境のプラグイン未登録）が
+    // 未処理の非同期エラーにならないよう握りつぶす。
+    ref.onDispose(() {
+      unawaited(_service.dispose().catchError((Object _) {}));
+    });
     // バックグラウンドでTTS初期化を開始（TASK-0090: TTS最適化）
     // build()完了後に非同期で初期化を実行することで、
     // 最初のspeak()呼び出し時の遅延を削減

--- a/frontend/kotonoha_app/test/features/ai_conversion/providers/ai_conversion_provider_test.dart
+++ b/frontend/kotonoha_app/test/features/ai_conversion/providers/ai_conversion_provider_test.dart
@@ -140,11 +140,11 @@ void main() {
 
         final notifier = container.read(aiConversionProvider.notifier);
 
-        // 非同期で変換開始
-        unawaited(notifier.convert(
+        // 非同期で変換開始（完了は後で待つ）
+        final convertFuture = notifier.convert(
           inputText: 'テスト',
           politenessLevel: PolitenessLevel.polite,
-        ));
+        );
 
         // 少し待ってconverting状態を確認
         await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -154,6 +154,10 @@ void main() {
         expect(state.isConverting, true);
         expect(state.originalText, 'テスト');
         expect(state.politenessLevel, PolitenessLevel.polite);
+
+        // テスト終了（container破棄）前に変換処理の完了を待ち、
+        // 破棄済みNotifierへのstate更新（failed after test completion）を防ぐ。
+        await convertFuture;
       });
 
       // TC-070-004: convert成功で状態がsuccessになり結果が設定される

--- a/frontend/kotonoha_app/test/features/history/presentation/history_actions_test.dart
+++ b/frontend/kotonoha_app/test/features/history/presentation/history_actions_test.dart
@@ -319,6 +319,11 @@ void main() {
           ),
         );
 
+        // When: 対象の履歴項目をタップして読み上げ対象に設定する
+        // （読み上げ中表示は項目単位で管理されるため、タップで対象を確定する）
+        await tester.tap(find.text('こんにちは'));
+        await tester.pump();
+
         // Then: 読み上げ中のインジケーター（例: アイコン、背景色変更など）が表示される
         // 実装に応じて検証方法を調整
         // 例: 読み上げ中アイコンの存在確認
@@ -353,6 +358,7 @@ void main() {
           state: TTSState.speaking,
           currentSpeed: TTSSpeed.normal,
         );
+        when(() => mockTTSNotifier.speak(any())).thenAnswer((_) async {});
         when(() => mockTTSNotifier.stop()).thenAnswer((_) async {});
 
         await tester.pumpWidget(
@@ -367,11 +373,73 @@ void main() {
           ),
         );
 
+        // When: 対象の履歴項目をタップして読み上げ対象に設定する
+        await tester.tap(find.text('こんにちは'));
+        await tester.pump();
+
         // Then: 停止ボタンが表示される
         expect(
           find.byIcon(Icons.stop),
           findsOneWidget,
           reason: '読み上げ中は停止ボタンが表示される必要がある',
+        );
+      });
+
+      /// TC-063-006: 読み上げ中表示は対象項目のみ（per-item）テスト 🔵
+      ///
+      /// 検証内容: 複数履歴で1件を読み上げ中にしたとき、その項目だけが
+      /// 読み上げ中表示（停止アイコン）になり、他の項目は通常表示のままであること。
+      /// （以前はTTSのspeaking状態を全カードに渡しており、全カードが停止表示になっていた）
+      testWidgets('TC-063-006: 読み上げ中表示は対象の1項目のみ', (WidgetTester tester) async {
+        // Given: 履歴を2件準備する
+        final histories = [
+          createTestHistory(
+            id: 'item_a',
+            content: '項目A',
+            type: HistoryType.manualInput,
+          ),
+          createTestHistory(
+            id: 'item_b',
+            content: '項目B',
+            type: HistoryType.manualInput,
+          ),
+        ];
+        final mockState = HistoryState(histories: histories);
+
+        final mockTTSNotifier = MockTTSNotifier();
+        mockTTSNotifier.mockInitialState = const TTSServiceState(
+          state: TTSState.speaking,
+          currentSpeed: TTSSpeed.normal,
+        );
+        when(() => mockTTSNotifier.speak(any())).thenAnswer((_) async {});
+        when(() => mockTTSNotifier.stop()).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              historyProviderOverride(mockState),
+              ttsProvider.overrideWith(() => mockTTSNotifier),
+            ],
+            child: const MaterialApp(
+              home: HistoryScreen(),
+            ),
+          ),
+        );
+
+        // When: 項目Aのみをタップする
+        await tester.tap(find.text('項目A'));
+        await tester.pump();
+
+        // Then: 読み上げ中（停止）アイコンはちょうど1つ（項目Aのみ）
+        expect(
+          find.byIcon(Icons.stop),
+          findsOneWidget,
+          reason: '読み上げ中表示はタップした1項目のみであるべき',
+        );
+        expect(
+          find.byIcon(Icons.volume_up),
+          findsOneWidget,
+          reason: '読み上げ中アイコンはタップした1項目のみであるべき',
         );
       });
     });


### PR DESCRIPTION
## 概要
コードレビュー(High)で指摘したフロントエンドの状態/ライフサイクル問題を修正します。

## 変更内容
### 1. 履歴画面の読み上げ中表示バグ（per-item化）
- 以前は `isSpeaking: ttsState.state == TTSState.speaking` を**全カードに一律**で渡していたため、1件を読み上げ中にすると**全カードが停止アイコンに変化**していました。
- `HistoryScreen` を `ConsumerStatefulWidget` 化し、読み上げ対象の項目ID(`_speakingId`)を保持。`isSpeaking = speaking && _speakingId == history.id` とし、該当項目のみ読み上げ中表示にします。TTSがspeaking以外へ遷移したらハイライトを解除。

### 2. Providerのリソースリーク防止（ref.onDispose）
- `TTSNotifier`: 破棄時に `TTSService.dispose()` でネイティブTTSを解放。dispose内のネイティブ呼び出し失敗（テスト環境のプラグイン未登録等）が未処理の非同期エラーにならないよう `catchError` で握りつぶし。
- `aiConversionApiClientProvider`: `Dio.close()` で接続リソースを解放。
- `NetworkNotifier`: `StreamSubscription` を `cleanup()` で解放。

## テスト
- 追加: per-item表示の回帰テスト（複数履歴で1件のみ読み上げ中表示）。
- 更新: 既存の読み上げ中アイコン/停止ボタンテストを「タップ起点」に変更（per-item挙動に整合）。
- `flutter test`: **All tests passed!（1458件）**、`flutter analyze` 指摘ゼロ、`dart format` 準拠。

## スコープ外（別途）
- 設定の二重 `AppSettings`（`shared/models/app_settings.dart` + `AppSettingsRepository`）の整理は、複数テストが依存しており削除にテスト改変を伴うため本PRから除外しました（実アプリでは未使用で実害は理論上のみ）。別PRで対応可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)